### PR TITLE
DOC: show "Edit on Github" link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,6 +61,9 @@ html_theme_options = {
     'logo_only': False,
     'wide_pages': ['usage'],
 }
+html_context = {
+    'display_github': True,
+}
 html_title = title
 html_static_path = ['_static']
 


### PR DESCRIPTION
The default i setting is to show a link to Gitlab in the right corner of the docs, this changes the link to Github.