### PR TITLE
DOC: add code coverage badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 openSMILE Python
 ================
 
-|tests| |docs| |python-versions| |license| 
+|tests| |coverage| |docs| |python-versions| |license| 
 
 Python interface for extracting openSMILE_ features.
 
@@ -96,6 +96,9 @@ Please cite openSMILE in your publications by citing the following paper:
 .. |tests| image:: https://github.com/audeering/opensmile-python/workflows/Test/badge.svg
     :target: https://github.com/audeering/opensmile-python/actions?query=workflow%3ATest
     :alt: Test status
+.. |coverage| image:: https://codecov.io/gh/audeering/opensmile-python/branch/master/graph/badge.svg?token=PUA9P2UJW1
+    :target: https://codecov.io/gh/audeering/opensmile-python
+    :alt: code coverage
 .. |docs| image:: https://img.shields.io/pypi/v/opensmile?label=docs
     :target: https://audeering.github.io/opensmile/
     :alt: opensmile's documentation


### PR DESCRIPTION
After the first coverage report is submitted to codecov.io, we can add a badge to the README.