### PR TITLE
Fix building docs in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,10 @@ jobs:
         python setup.py sdist bdist_wheel
         python -m twine upload dist/*
     # Docuemntation
+    - name: Setup Ubuntu
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install libsndfile1 sox
     - name: Install doc dependencies
       run: |
         pip install -r requirements.txt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
         python -m twine upload dist/*
-    # Docuemntation
+    # Documentation
     - name: Setup Ubuntu
       run: |
         sudo apt-get update


### PR DESCRIPTION
In the publish workflow, we forgot to install `sox` and `libsndfile`.