### PR TITLE
Update pip in doc environment for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,7 @@ jobs:
         sudo apt-get -y install libsndfile1 sox
     - name: Install doc dependencies
       run: |
+        python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r docs/requirements.txt
     - name: Build documentation


### PR DESCRIPTION
Building of the documentation was stuck for a long time during publishing:
https://github.com/audeering/opensmile-python/runs/1299682501?check_suite_focus=true

This does not happen inside the test actions. This updates `pip` as is done inside the test actions, maybe this helps.