### PR TITLE
Multi-line support in changelog of Github releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
       id: changelog
       run: |
         # Get bullet points from last CHANGELOG entry
-        CHANGELOG=$(git diff -U0 HEAD^ HEAD | grep '^[+]\*' | sed 's/\+//')
+        CHANGELOG=$(git diff -U0 HEAD^ HEAD | grep '^[+][\* ]' | sed 's/\+//')
         # Support for multiline, see
         # https://github.com/actions/create-release/pull/11#issuecomment-640071918
         CHANGELOG="${CHANGELOG//'%'/'%25'}"


### PR DESCRIPTION
Before only lines starting with `*` where included from the changelog to the Github release,
this now also includes lines starting with ` ` to support multi-line entries.