### PR TITLE
DOC: include FeatureLevel and FeatureSet

### DIFF
--- a/docs/api-smile.rst
+++ b/docs/api-smile.rst
@@ -7,6 +7,18 @@ config
 .. autoclass:: opensmile.config
     :members:
 
+FeatureLevel
+------------
+
+.. autoclass:: opensmile.FeatureLevel
+    :members:
+
+FeatureSet
+----------
+
+.. autoclass:: opensmile.FeatureSet
+    :members:
+
 Smile
 -----
 

--- a/opensmile/core/define.py
+++ b/opensmile/core/define.py
@@ -1,5 +1,4 @@
 import enum
-import typing
 
 
 class FeatureSet(enum.Enum):


### PR DESCRIPTION
This adds the classes `FeatureLevel` and `FeatureSet` to the documentation.