### PR TITLE
TST: reenable Windows tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # os: [ ubuntu-latest, windows-latest, macos-latest ]
-        # disable windows tests until
-        # https://github.com/audeering/audresample/pull/5
-        # is fixed
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
         python-version: [ 3.6, 3.7, 3.8 ]
 
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifiers =
 packages = find:
 install_requires =
     audobject >=0.4.6,<0.6.0
-    audinterface >=0.6.5,<0.8.0
+    audinterface >=0.6.6,<0.8.0
 setup_requires =
     setuptools_scm
 


### PR DESCRIPTION
Since `audresample` finally supports Windows (see https://github.com/audeering/audresample/pull/5) we can re-enable tests here, too.