### PR TITLE
FIX: __call__() return correct shape 

### DIFF
--- a/opensmile/core/smile.py
+++ b/opensmile/core/smile.py
@@ -467,4 +467,9 @@ class Smile(audinterface.Feature, audobject.Object):
             RuntimeError: if channel selection is invalid
 
         """
-        return super().__call__(signal, sampling_rate)[-1]
+        # process functions returns (starts, values, values)
+        # but we only want to return values here
+        y = self.process(signal, sampling_rate)[2]
+        # reshape to (channels, features, frames)
+        y = y.T.reshape(self.num_channels, self.num_features, -1)
+        return y

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifiers =
 packages = find:
 install_requires =
     audobject >=0.4.6,<0.6.0
-    audinterface >=0.6.6,<0.8.0
+    audinterface >=0.7.0,<0.9.0
 setup_requires =
     setuptools_scm
 

--- a/tests/test_smile.py
+++ b/tests/test_smile.py
@@ -332,7 +332,8 @@ def test_signal(file, feature_set, feature_level):
 
     # assertions
 
+    assert y_call.ndim == 3
     assert fex.feature_names == y.columns.to_list()
     np.testing.assert_equal(y.values, y_file.values)
-    np.testing.assert_equal(y.values, y_call)
+    np.testing.assert_equal(y.values.squeeze(), y_call.squeeze().T)
     assert all(y_empty.isna())


### PR DESCRIPTION
With `audinterface>=0.7.0` we changed that `Feature.__call__()` always returns the shape `(channels, feature, frames)`. Since we have to override `__call__()` in `Smile` - due to the fact that the process function returns not just the feature values but also the start and end times of the segments returned by `opensmile` - we need to provide a fix here, too.