### PR TITLE
Added FeatureSetResolver and FeatureLevelResolver to API

### DIFF
--- a/opensmile/__init__.py
+++ b/opensmile/__init__.py
@@ -1,7 +1,9 @@
 from opensmile.core.config import config
 from opensmile.core.define import (
     FeatureSet,
+    FeatureSetResolver,
     FeatureLevel,
+    FeatureLevelResolver,
 )
 from opensmile.core.smile import (
     Smile,


### PR DESCRIPTION
I'm working on incorporation of opensmile-python within the [Lhotse ](https://github.com/lhotse-speech/lhotse) project by creating a simple wrapper. I would like to keep opensmile as an optional package and simplify API for human users. 
I found that despite FeatureLevel might be set with simple string "lld" or "func" strings, FeatureSet required importing opensmile.FeatureSet for the place where a user can declare predefined feature set. FeatureSetResolver allows for decoding FeatureSet object from string, but was not available in the opensmile API after installation with pip. The proposed change solves the problem.