### PR TITLE
Update Python package metadata syntax

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,14 @@
 [metadata]
 name = opensmile
 author = Johannes Wagner, Christoph Hausner, Hagen Wierstorf
-author-email = jwagner@audeering.com, chausner@audeering.com, hwierstorf@audeering.com
+author_email = jwagner@audeering.com, chausner@audeering.com, hwierstorf@audeering.com
 url = https://github.com/audeering/opensmile-python/
-project-urls =
+project_urls =
     Documentation = https://audeering.github.io/opensmile-python/
 description = Python wrapper for common openSMILE feature sets
-long-description = file: README.rst
+long_description = file: README.rst
 license = audEERING
-license-file = LICENSE
+license_file = LICENSE
 keywords = audio, tools, feature, opensmile, audeering
 platforms= any
 classifiers =


### PR DESCRIPTION
Replace deprecated `abc-def` entries with `abc_def` in `setup.cfg`.