### PR TITLE
Remove support for Python 3.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Topic :: Scientific/Engineering


### PR DESCRIPTION
Python 3.6 is no longer maintained and we also have no longer runner for the tests on Github.