### PR TITLE
CI: use extra job for pre-commit test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,14 +36,6 @@ jobs:
         pip install -r docs/requirements.txt
         pip install -r tests/requirements.txt
 
-    - name: Install pre-commit hooks
-      run: |
-        pre-commit install --install-hooks
-
-    - name: Code style check via pre-commit
-      run: |
-        pre-commit run --all-files
-
     - name: Test with pytest
       run: |
         python -m pytest


### PR DESCRIPTION
As it makes sense to test only once for PEP8, we move the job to an extra action workflow.