### PR TITLE
CI: fix uploading of Python package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: artifact
-        path: dist
+        path: wheelhouse
 
     - name: Set up Python
       uses: actions/setup-python@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install twine
 
     # PyPI package
     - name: Build and publish
@@ -80,8 +80,7 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
-        python -m twine upload dist/*
+        python -m twine upload wheelhouse/*
 
     # Documentation
     - name: Setup Ubuntu


### PR DESCRIPTION
It removes some legacy codes and uploads from the new `wheelhouse` folder.