### PR TITLE
CI: fix permissions for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,6 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
     strategy:
       matrix:
         platform:
@@ -58,6 +56,10 @@ jobs:
 
     runs-on: 'ubuntu-latest'
     needs: [ build ]
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
 


### PR DESCRIPTION
Applies the fixes to publishing tested in `audresample` for the case of wheel packages.