### PR TITLE
Remove support for Python 3.8

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.8' ]
+        python-version: [ '3.10' ]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,10 +29,10 @@ jobs:
       with:
         fetch-depth: 2
 
-    - name: Set up Python 3.8
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Install build dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.9', '3.10', '3.11' ]
 
     steps:
     - uses: actions/checkout@v3

--- a/opensmile/core/define.py
+++ b/opensmile/core/define.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import enum
-import typing
 
 import audobject
 
@@ -49,12 +50,12 @@ class FeatureSet(enum.Enum):
 class FeatureSetResolver(audobject.resolver.Base):
     r"""Custom value resolver for :class:`opensmile.FeatureSet`."""
 
-    def decode(self, value: str) -> typing.Union[str, FeatureSet]:
+    def decode(self, value: str) -> str | FeatureSet:
         if value in FeatureSet.__members__:
             value = FeatureSet[value]
         return value
 
-    def encode(self, value: typing.Union[str, FeatureSet]) -> str:
+    def encode(self, value: str | FeatureSet) -> str:
         if isinstance(value, FeatureSet):
             value = str(value).split(".")[-1]
         return value
@@ -84,12 +85,12 @@ class FeatureLevel(enum.Enum):
 class FeatureLevelResolver(audobject.resolver.Base):
     r"""Custom value resolver for :class:`opensmile.FeatureLevel`."""
 
-    def decode(self, value: str) -> typing.Union[str, FeatureLevel]:
+    def decode(self, value: str) -> str | FeatureLevel:
         if value in FeatureLevel.__members__:
             value = FeatureLevel[value]
         return value
 
-    def encode(self, value: typing.Union[str, FeatureLevel]) -> str:
+    def encode(self, value: str | FeatureLevel) -> str:
         if isinstance(value, FeatureLevel):
             value = str(value).split(".")[-1]
         return value

--- a/opensmile/core/lib.py
+++ b/opensmile/core/lib.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from ctypes import CFUNCTYPE
 from ctypes import POINTER
 from ctypes import Structure
@@ -14,11 +15,6 @@ from ctypes import cdll
 import json
 import os
 import platform
-from typing import Any
-from typing import Callable
-from typing import Dict
-from typing import List
-from typing import Optional
 
 import numpy as np
 
@@ -290,7 +286,7 @@ def c_char_p_arr(x):
 class OpenSmileException(Exception):  # pragma: no cover
     """Exception thrown for internal openSMILE errors."""
 
-    def __init__(self, code: int, message: Optional[str] = None):
+    def __init__(self, code: int, message: str = None):
         self.code = code
         self.message = message
 
@@ -310,7 +306,7 @@ class OpenSMILE(object):  # pragma: no cover
     def initialize(
         self,
         config_file: str,
-        options: Dict[str, Any] = None,
+        options: dict[str, object] = None,
         loglevel: int = 2,
         debug: bool = False,
         console_output: bool = False,
@@ -517,7 +513,7 @@ class OpenSMILE(object):  # pragma: no cover
         )
 
     def external_message_interface_set_json_callback(
-        self, component_name: str, callback: Callable[[Dict], None]
+        self, component_name: str, callback: Callable[[dict], None]
     ):
         """Sets callback for cExternalMessageInterface.
 
@@ -586,10 +582,10 @@ class OpenSMILE(object):  # pragma: no cover
     @staticmethod
     def process(
         config_file: str,
-        options: Dict[str, Any],
-        inputs: Dict[str, np.ndarray],
-        outputs: List[str],
-    ) -> Dict[str, np.ndarray]:
+        options: dict[str, object],
+        inputs: dict[str, np.ndarray],
+        outputs: list[str],
+    ) -> dict[str, np.ndarray]:
         """Runs config on a set of input buffers.
 
         Returns the specified set of output buffers.

--- a/opensmile/core/smile.py
+++ b/opensmile/core/smile.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from collections.abc import Sequence
 import errno
 import os
-import typing
 import warnings
 
 import numpy as np
@@ -133,19 +136,19 @@ class Smile(audinterface.Feature, audobject.Object):
     )
     def __init__(
         self,
-        feature_set: typing.Union[str, FeatureSet] = FeatureSet.ComParE_2016,
-        feature_level: typing.Union[str, FeatureLevel] = FeatureLevel.Functionals,
+        feature_set: str | FeatureSet = FeatureSet.ComParE_2016,
+        feature_level: str | FeatureLevel = FeatureLevel.Functionals,
         *,
         options: dict = None,
         loglevel: int = 2,
         logfile: str = None,
         sampling_rate: int = None,
-        channels: typing.Union[int, typing.Sequence[int]] = 0,
+        channels: int | Sequence[int] = 0,
         mixdown: bool = False,
         resample: bool = False,
         segment: audinterface.Segment = None,
         keep_nat: bool = False,
-        num_workers: typing.Optional[int] = 1,
+        num_workers: int | None = 1,
         multiprocessing: bool = False,
         verbose: bool = False,
     ):
@@ -310,7 +313,7 @@ class Smile(audinterface.Feature, audobject.Object):
 
         return starts, ends, np.concatenate(ys, axis=1)
 
-    def _feature_names(self) -> typing.List[str]:
+    def _feature_names(self) -> list[str]:
         r"""Read feature names from config file."""
         options = self._options()
         options["source"] = os.path.join(
@@ -418,8 +421,8 @@ class Smile(audinterface.Feature, audobject.Object):
 
     @staticmethod
     def _sink_callback(
-        y: typing.List[np.ndarray], starts: typing.List[float], ends: typing.List[float]
-    ) -> typing.Callable[[np.ndarray, FrameMetaData], None]:
+        y: list[np.ndarray], starts: list[float], ends: list[float]
+    ) -> Callable[[np.ndarray, FrameMetaData], None]:
         r"""Return callback where features are collected."""
 
         def callback(data: np.ndarray, meta: FrameMetaData):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Topic :: Scientific/Engineering',
 ]
+requires-python = '>=3.9'
 dependencies = [
     'audobject >=0.6.1',
     'audinterface >=0.7.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
Remove support for Python 3.8.

It also updates the code by stop using `typing`.

## Summary by Sourcery

Remove support for Python 3.8 and update type annotations to use PEP 604 syntax. Update CI workflows to drop Python 3.8 and use Python 3.9, 3.10, and 3.11. Adjust project metadata to reflect the new minimum Python version requirement of 3.9.

Enhancements:
- Update type annotations to use PEP 604 syntax for type hinting.

CI:
- Update CI workflows to use Python 3.9, 3.10, and 3.11 instead of 3.8.