### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ '3.9', '3.10', '3.11' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
 
     steps:
     - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ classifiers = [
 ]
 requires-python = '>=3.9'
 dependencies = [
-    'audobject >=0.7.11',
-    'audinterface >=1.2.3',
+    'audobject >=0.6.1',
+    'audinterface >=0.7.11',
 ]
 # Get version dynamically from git
 # (needs setuptools_scm tools config below)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,12 +28,13 @@ classifiers = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'Topic :: Scientific/Engineering',
 ]
 requires-python = '>=3.9'
 dependencies = [
-    'audobject >=0.6.1',
-    'audinterface >=0.7.0',
+    'audobject >=0.7.11',
+    'audinterface >=1.2.3',
 ]
 # Get version dynamically from git
 # (needs setuptools_scm tools config below)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 requires-python = '>=3.9'
 dependencies = [
     'audobject >=0.6.1',
-    'audinterface >=0.7.11',
+    'audinterface >=0.7.0',
 ]
 # Get version dynamically from git
 # (needs setuptools_scm tools config below)


### PR DESCRIPTION
Closes #108 

Adds Python 3.12 as supported version to the Python package and enables tests for it in Ubuntu runners.

## Summary by Sourcery

Add support for Python 3.12 and update dependencies. Enable CI testing for Python 3.12 on Ubuntu.

New Features:
- Add support for Python 3.12 in the project.

Enhancements:
- Update dependencies to 'audobject >=0.7.11' and 'audinterface >=1.2.3'.

CI:
- Enable testing for Python 3.12 on Ubuntu runners in the CI workflow.