### PR TITLE
CI: use different artifacts names in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
+        name: ${{ matrix.platform }}
         path: ./wheelhouse/*
 
   deploy:


### PR DESCRIPTION
In https://github.com/audeering/opensmile-python/pull/113 we updated the actions used to upload and download Artifacts in the `publish.yml` workflow. This leads to an [error when trying to publish](https://github.com/audeering/opensmile-python/actions/runs/12354154801/job/34474855369) as the artifacts need to have different names now.

This is fixed in this pull request by using the platform for which the artifact is built for as name.

## Summary by Sourcery

CI:
- Update artifact naming in publish.yml to use platform-specific names, resolving publishing errors.