### PR TITLE
Revert "Release 2.5.1 (#117)"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,14 +7,6 @@ The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
 
-Version 2.5.1 (2024-12-16)
---------------------------
-
-* Added: support for Python 3.12
-* Added: support for Python 3.13
-* Removed: support for Python 3.8
-
-
 Version 2.5.0 (2023-10-19)
 --------------------------
 


### PR DESCRIPTION
This reverts commit 69617fa0d6d220b97c6e973d290e3308a1ea040a.

As we did not publish anything, we can revert the changelog and do another attempt on publication.