### PR TITLE
Added is09-13 configs

### DIFF
--- a/opensmile/core/config/is09-13/IS09_emotion.conf
+++ b/opensmile/core/config/is09-13/IS09_emotion.conf
@@ -1,0 +1,63 @@
+///////////////////////////////////////////////////////////////////////////////////////
+///////// > openSMILE configuration file for IS09 emotion challenge< //////////////////
+/////////                                                            //////////////////
+///////// (c) 2014 by audEERING                                      //////////////////
+/////////     All rights reserved. See file COPYING for details.     //////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////////////////
+;
+; This section is always required in openSMILE configuration files
+;   it configures the componentManager and gives a list of all components which are to be loaded
+; The order in which the components are listed should match 
+;   the order of the data flow for most efficient processing
+;
+///////////////////////////////////////////////////////////////////////////////////////
+[componentInstances:cComponentManager]
+ ; this line configures the default data memory:
+instance[dataMemory].type=cDataMemory
+printLevelStats=0
+nThreads=1
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////   component configuration  ////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////
+; the following sections configure the components listed above
+; a help on configuration parameters can be obtained with 
+;  SMILExtract -H
+; or
+;  SMILExtract -H configTypeName (= componentTypeName)
+/////////////////////////////////////////////////////////////////////////////////////////////
+
+\{\cm[source{?}:include external source]}
+\{IS09_emotion_core.lld.conf.inc}
+\{IS09_emotion_core.func.conf.inc}
+
+; TODO: alias levels in code: cVectorConcat (if 1:1 input (single level) to output mapping) 
+;   registers an alias level instead of actually copying
+;   this maintains compatibility with old config files, but is more efficient in new code
+
+;;;;;;;;; prepare features for standard output module
+
+[componentInstances:cComponentManager]
+instance[lldconcat].type=cVectorConcat
+instance[llddeconcat].type=cVectorConcat
+instance[funcconcat].type=cVectorConcat
+
+[lldconcat:cVectorConcat]
+reader.dmLevel = is09_lld
+writer.dmLevel = lld
+includeSingleElementFields = 1
+
+[llddeconcat:cVectorConcat]
+reader.dmLevel = is09_lld_de
+writer.dmLevel = lld_de
+includeSingleElementFields = 1
+
+[funcconcat:cVectorConcat]
+reader.dmLevel = is09_func
+writer.dmLevel = func
+includeSingleElementFields = 1
+
+\{\cm[sink{?}:include external sink]}
+

--- a/opensmile/core/config/is09-13/IS09_emotion_core.func.conf.inc
+++ b/opensmile/core/config/is09-13/IS09_emotion_core.func.conf.inc
@@ -1,0 +1,63 @@
+
+///////////////////////////////////////////////////////////////////////////////////////
+///////// > openSMILE configuration file for IS09 emotion challenge< //////////////////
+///////// > core features <                                          //////////////////
+///////// (c) 2014 by audEERING                                      //////////////////
+/////////     All rights reserved. See file COPYING for details.     //////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+
+
+///////////////////////////////////////////////////////////////////////////////////////
+;
+; This section is always required in openSMILE configuration files
+;   it configures the componentManager and gives a list of all components which are to be loaded
+; The order in which the components are listed should match 
+;   the order of the data flow for most efficient processing
+;
+///////////////////////////////////////////////////////////////////////////////////////
+[componentInstances:cComponentManager]
+instance[is09_functL1].type=cFunctionals
+
+
+[is09_functL1:cFunctionals]
+reader.dmLevel=is09_lld;is09_lld_de
+writer.dmLevel=is09_func
+copyInputName = 1
+\{\cm[bufferModeRbConf]}
+\{\cm[frameModeFunctionalsConf{../shared/FrameModeFunctionals.conf.inc}:path to included config to set frame mode for all functionals]}
+functionalsEnabled=Extremes;Regression;Moments
+Extremes.max = 1
+Extremes.min = 1
+Extremes.range = 1
+Extremes.maxpos = 1
+Extremes.minpos = 1
+Extremes.amean = 1
+Extremes.maxameandist = 0
+Extremes.minameandist = 0
+ ; Note: the much better way to normalise the times of maxpos and minpos
+ ; is 'turn', however for compatibility with old files the default 'frame'
+ ; is kept here:
+Extremes.norm = frame
+Regression.linregc1 = 1
+Regression.linregc2 = 1
+Regression.linregerrA = 0
+Regression.linregerrQ = 1
+Regression.qregc1 = 0
+Regression.qregc2 = 0
+Regression.qregc3 = 0
+Regression.qregerrA = 0
+Regression.qregerrQ = 0
+Regression.centroid = 0
+Regression.oldBuggyQerr = 1
+Regression.normInputs = 0
+Regression.normRegCoeff = 0
+Regression.centroidRatioLimit = 0
+Regression.doRatioLimit = 0
+Moments.doRatioLimit = 0
+Moments.variance = 0
+Moments.stddev = 1
+Moments.skewness = 1
+Moments.kurtosis = 1
+Moments.amean = 0
+
+

--- a/opensmile/core/config/is09-13/IS09_emotion_core.lld.conf.inc
+++ b/opensmile/core/config/is09-13/IS09_emotion_core.lld.conf.inc
@@ -1,0 +1,185 @@
+///////////////////////////////////////////////////////////////////////////////////////
+///////// > openSMILE configuration file for IS09 emotion challenge< //////////////////
+///////// > core features <                                          //////////////////
+///////// (c) 2014 by audEERING                                      //////////////////
+/////////     All rights reserved. See file COPYING for details.     //////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+
+
+///////////////////////////////////////////////////////////////////////////////////////
+;
+; This section is always required in openSMILE configuration files
+;   it configures the componentManager and gives a list of all components which are to be loaded
+; The order in which the components are listed should match 
+;   the order of the data flow for most efficient processing
+;
+///////////////////////////////////////////////////////////////////////////////////////
+[componentInstances:cComponentManager]
+instance[is09_fr1].type=cFramer
+instance[is09_pe2].type=cVectorPreemphasis
+instance[is09_w1].type=cWindower
+instance[is09_fft1].type=cTransformFFT
+instance[is09_fftmp1].type=cFFTmagphase
+instance[is09_mspec].type=cMelspec
+instance[is09_mfcc].type=cMfcc
+instance[is09_mzcr].type=cMZcr
+instance[is09_acf].type=cAcf
+instance[is09_cepstrum].type=cAcf
+instance[is09_pitchACF].type=cPitchACF
+instance[is09_energy].type=cEnergy
+instance[is09_lld].type=cContourSmoother
+instance[is09_delta1].type=cDeltaRegression
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////   component configuration  ////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////
+; the following sections configure the components listed above
+; a help on configuration parameters can be obtained with 
+;  SMILExtract -H
+; or
+;  SMILExtract -H configTypeName (= componentTypeName)
+/////////////////////////////////////////////////////////////////////////////////////////////
+
+[is09_fr1:cFramer]
+reader.dmLevel=wave
+writer.dmLevel=is09_frames
+\{\cm[bufferModeRbConf{../shared/BufferModeRb.conf.inc}:path to included config to set the buffer mode for the standard ringbuffer levels]}
+copyInputName = 1
+noPostEOIprocessing = 1
+frameSize = 0.0250
+frameStep = 0.010
+frameMode = fixed
+frameCenterSpecial = left
+
+[is09_pe2:cVectorPreemphasis]
+reader.dmLevel=is09_frames
+writer.dmLevel=is09_framespe
+copyInputName = 1
+processArrayFields = 1
+k=0.97
+de = 0
+
+[is09_w1:cWindower]
+reader.dmLevel=is09_framespe
+writer.dmLevel=is09_winframe
+copyInputName = 1
+processArrayFields = 1
+winFunc = ham
+gain = 1.0
+offset = 0
+
+  // ---- LLD -----
+
+[is09_fft1:cTransformFFT]
+reader.dmLevel=is09_winframe
+writer.dmLevel=is09_fftc
+copyInputName = 1
+processArrayFields = 1
+inverse = 0
+ ; for compatibility with 2.2.0 and older versions
+zeroPadSymmetric = 0
+
+[is09_fftmp1:cFFTmagphase]
+reader.dmLevel=is09_fftc
+writer.dmLevel=is09_fftmag
+copyInputName = 1
+processArrayFields = 1
+inverse = 0
+magnitude = 1
+phase = 0
+
+[is09_mspec:cMelspec]
+reader.dmLevel=is09_fftmag
+writer.dmLevel=is09_mspec1
+copyInputName = 1
+processArrayFields = 1
+htkcompatible = 1
+nBands = 26
+usePower = 0
+lofreq = 0
+hifreq = 8000
+inverse = 0
+specScale = mel
+
+[is09_mfcc:cMfcc]
+reader.dmLevel=is09_mspec1
+writer.dmLevel=is09_mfcc1
+copyInputName = 1
+processArrayFields = 1
+firstMfcc = 1
+lastMfcc =  12
+cepLifter = 22.0
+htkcompatible = 1
+
+
+[is09_acf:cAcf]
+reader.dmLevel=is09_fftmag
+writer.dmLevel=is09_acf
+nameAppend = acf
+copyInputName = 1
+processArrayFields = 1
+usePower = 1
+cepstrum = 0
+
+[is09_cepstrum:cAcf]
+reader.dmLevel=is09_fftmag
+writer.dmLevel=is09_cepstrum
+nameAppend = acf
+copyInputName = 1
+processArrayFields = 1
+usePower = 1
+cepstrum = 1
+
+[is09_pitchACF:cPitchACF]
+  ; the pitchACF component must ALWAYS read from acf AND cepstrum in the given order!
+reader.dmLevel=is09_acf;is09_cepstrum
+writer.dmLevel=is09_pitch
+copyInputName = 1
+processArrayFields=0
+maxPitch = 500
+voiceProb = 1
+voiceQual = 0
+HNR = 0
+F0 = 1
+F0raw = 0
+F0env = 0
+voicingCutoff = 0.550000
+
+[is09_energy:cEnergy]
+reader.dmLevel=is09_winframe
+writer.dmLevel=is09_energy
+nameAppend=energy
+rms=1
+log=0
+
+[is09_mzcr:cMZcr]
+reader.dmLevel=is09_frames
+writer.dmLevel=is09_mzcr
+copyInputName = 1
+processArrayFields = 1
+zcr = 1
+amax = 0
+mcr = 0
+maxmin = 0
+dc = 0
+
+[is09_lld:cContourSmoother]
+reader.dmLevel=is09_energy;is09_mfcc1;is09_mzcr;is09_pitch
+writer.dmLevel=is09_lld
+\{\cm[bufferModeConf{../shared/BufferMode.conf.inc}:path to included config to set buffer mode for all LLD that feed into functionals]}
+nameAppend = sma
+copyInputName = 1
+noPostEOIprocessing = 0
+smaWin = 3
+
+// ---- delta regression of LLD ----
+[is09_delta1:cDeltaRegression]
+reader.dmLevel=is09_lld
+writer.dmLevel=is09_lld_de
+\{\cm[bufferModeConf]}
+nameAppend = de
+copyInputName = 1
+noPostEOIprocessing = 0
+deltawin=2
+blocksize=1
+

--- a/opensmile/core/config/is09-13/IS10_paraling_compat.conf
+++ b/opensmile/core/config/is09-13/IS10_paraling_compat.conf
@@ -1,0 +1,545 @@
+
+///////////////////////////////////////////////////////////////////////////////////////
+///////// > openSMILE configuration file for IS10 features <         //////////////////
+/////////                                                            //////////////////
+///////// (c) 2014 by audEERING                                      //////////////////
+/////////     All rights reserved. See file COPYING for details.     //////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+
+
+// NOTE: This file is for version 2.1 and above and produces 
+// numerically compatible output to the original IS10 set,
+// EXCEPT for Jitter/Shimmer, as some bugs have been fixed there 
+// w/o maintaining backwards compatibility.
+
+// For new designs one should however use the IS10_paraling.conf which 
+// returns incompatible, yet enhanced and fixed features.
+
+
+//
+// Usage:
+// SMILExtract -C thisconfig.conf -I input.wav -O output.arff 
+//
+ 
+///////////////////////////////////////////////////////////////////////////////////////
+;
+; This section is always required in openSMILE configuration files
+;   it configures the componentManager and gives a list of all components which are to be loaded
+; The order in which the components are listed should match 
+;   the order of the data flow for most efficient processing
+;
+///////////////////////////////////////////////////////////////////////////////////////
+[componentInstances:cComponentManager]
+ ; this line configures the default data memory:
+instance[dataMemory].type=cDataMemory
+ ;;; 40 ms frames features:
+instance[fr40].type=cFramer
+instance[w40].type=cWindower
+instance[fft40].type=cTransformFFT
+instance[fftmagphase40].type=cFFTmagphase
+ ; SHS Pitch:
+instance[scale].type=cSpecScale
+instance[pitchShs].type=cPitchShs
+instance[pitchSmooth].type=cPitchSmoother
+instance[pitchJitter].type=cPitchJitter
+instance[pitchSmooth2].type=cPitchSmoother
+instance[res].type=cSpecResample
+
+ ;;; 25 ms frames features:
+instance[fr25].type=cFramer
+instance[pe].type=cVectorPreemphasis
+instance[win].type=cWindower
+instance[fft].type=cTransformFFT
+instance[fftmagphase].type=cFFTmagphase
+ ; mfcc
+instance[mspec].type=cMelspec
+instance[mfcc].type=cMfcc
+ ; log mel frequency bands (mfb)
+instance[mspec2].type=cMelspec
+instance[vo].type=cVectorOperation
+instance[lpc].type=cLpc
+ ; Line Spectral Frequencies
+instance[lsp].type=cLsp
+ ; Loudness (narrow-band approximation)
+instance[intens].type=cIntensity
+ ;;; all LLD concattenated and smoothed using a moving average filter
+instance[lld].type=cContourSmoother
+instance[lld2].type=cContourSmoother
+ ; delta coefficients of LLD
+instance[delta1].type=cDeltaRegression
+instance[delta2].type=cDeltaRegression
+ ;;; functionals over FULL input (e.g. turns)
+instance[functL1].type=cFunctionals
+instance[functL1nz].type=cFunctionals
+instance[functOnsets].type=cFunctionals
+
+;; run single threaded (nThreads=1)
+; NOTE: a single thread is more efficient for processing small files, since multi-threaded processing involves more 
+;       overhead during startup, which will make the system slower in the end
+nThreads=1
+;; do not show any internal dataMemory level settings 
+; (if you want to see them set the value to 1, 2, 3, or 4, depending on the amount of detail you wish)
+printLevelStats=0
+
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////   component configuration  ////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////
+; the following sections configure the components listed above
+; a help on configuration parameters can be obtained with 
+;  SMILExtract -H
+; or
+;  SMILExtract -H configTypeName (= componentTypeName)
+/////////////////////////////////////////////////////////////////////////////////////////////
+
+\{\cm[source{?}:include external source]}
+
+[fr40:cFramer]
+reader.dmLevel=wave
+writer.dmLevel=frames40
+frameMode = fixed
+frameSize = 0.060
+frameStep = 0.010
+frameCenterSpecial = left
+noPostEOIprocessing = 1
+
+[w40:cWindower]
+reader.dmLevel=frames40
+writer.dmLevel=win40frame
+winFunc = gauss
+sigma = 0.25
+gain = 1.0
+
+
+[fft40:cTransformFFT]
+reader.dmLevel=win40frame
+writer.dmLevel=fftc40
+ ; for compatibility with 2.2.0 and older versions
+zeroPadSymmetric = 0
+
+[fftmagphase40:cFFTmagphase]
+reader.dmLevel=fftc40
+writer.dmLevel=fftmag40
+magnitude = 1
+phase = 0
+
+[scale:cSpecScale]
+reader.dmLevel=fftmag40
+writer.dmLevel=hps
+scale=log
+ ; octave scale
+logScaleBase=2
+specSmooth = 0
+auditoryWeighting = 0
+specEnhance = 0
+minF = 25
+maxF = -1
+interpMethod = spline
+
+[pitchShs:cPitchShs]
+reader.dmLevel=hps
+writer.dmLevel=pitchShs
+F0raw = 0
+voicingClip = 0
+voicingC1=0
+scores=1
+voicing=1
+nCandidates = 3
+octaveCorrection = 0
+greedyPeakAlgo = 0
+compressionFactor = 0.85
+nHarmonics = 15
+voicingCutoff = 0.75
+maxPitch = 620
+minPitch = 52
+
+[pitchSmooth:cPitchSmoother]
+reader.dmLevel=pitchShs
+writer.dmLevel=pitch
+F0raw = 0
+F0final = 0
+F0finalEnv = 1
+voicingFinalUnclipped = 1
+medianFilter0 = 0
+postSmoothingMethod = simple
+;simple
+octaveCorrection = 0
+writer.levelconf.nT=10
+;writer.levelconf.noHang=2
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+
+[pitchSmooth2:cPitchSmoother]
+reader.dmLevel=pitchShs
+writer.dmLevel=pitchF
+F0raw = 0
+F0final = 1
+F0finalEnv = 0
+voicingFinalUnclipped = 0
+medianFilter0 = 0
+postSmoothingMethod = simple
+octaveCorrection = 0
+writer.levelconf.nT=10
+;writer.levelconf.noHang=2
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+
+ ;;;; default (template) configuration section for component 'cPitchJitter' ;;;;
+[pitchJitter:cPitchJitter]
+reader.dmLevel = wave
+writer.dmLevel = jitter
+// nameAppend =
+copyInputName = 1
+F0reader.dmLevel = pitchF
+F0field = F0final
+searchRangeRel = 0.250000
+jitterLocal = 1
+jitterDDP = 1
+jitterLocalEnv = 0
+jitterDDPEnv = 0
+shimmerLocal = 1
+shimmerLocalEnv = 0
+onlyVoiced = 0
+;periodLengths = 0
+;periodStarts = 0
+inputMaxDelaySec = 1
+usePeakToPeakPeriodLength = 0
+shimmerUseRmsAmplitude = 0
+minCC = 0.5
+minNumPeriods = 2
+useBrokenJitterThresh = 1
+
+[fr25:cFramer]
+reader.dmLevel=wave
+writer.dmLevel=frames
+frameSize = 0.025
+frameStep = 0.010
+frameCenterSpecial = left
+
+[pe:cVectorPreemphasis]
+reader.dmLevel=frames
+writer.dmLevel=framespe
+k=0.97
+
+[win:cWindower]
+reader.dmLevel=framespe
+writer.dmLevel=winframe
+winFunc = ham
+gain = 1.0
+
+[fft:cTransformFFT]
+reader.dmLevel=winframe
+writer.dmLevel=fftc
+ ; for compatibility with 2.2.0 and older versions
+zeroPadSymmetric = 0
+
+[fftmagphase:cFFTmagphase]
+reader.dmLevel=fftc
+writer.dmLevel=fftmag
+magnitude = 1
+phase = 0
+
+[mspec:cMelspec]
+reader.dmLevel=fftmag
+writer.dmLevel=mspec1
+htkcompatible = 0
+usePower = 1
+lofreq = 20
+hifreq = 8000
+nBands=26
+specScale = mel
+bwMethod = lr
+
+[mfcc:cMfcc]
+reader.dmLevel = mspec1
+writer.dmLevel = mfcc
+htkcompatible = 0
+firstMfcc=0
+lastMfcc=14
+cepLifter=22
+copyInputName = 0
+
+[mspec2:cMelspec]
+reader.dmLevel=fftmag
+writer.dmLevel=mspec2
+htkcompatible = 0
+usePower = 1
+lofreq = 20
+hifreq = 6500
+nBands=8
+specScale = mel
+bwMethod = lr
+
+[vo:cVectorOperation]
+reader.dmLevel=mspec2
+writer.dmLevel=mspec2log
+operation = log
+copyInputName = 0
+nameAppend=logMelFreqBand
+
+[res:cSpecResample]
+reader.dmLevel=fftc
+writer.dmLevel=outpR
+targetFs = 11000
+
+[lpc:cLpc]
+;reader.dmLevel=framespe
+reader.dmLevel=outpR
+writer.dmLevel=lpc
+p=8
+method = acf
+saveLPCoeff = 1
+lpGain = 0
+saveRefCoeff = 0
+residual = 0
+forwardFilter = 0
+lpSpectrum = 0
+
+[lsp:cLsp]
+reader.dmLevel=lpc
+writer.dmLevel=lsp
+
+[intens:cIntensity]
+reader.dmLevel=frames
+writer.dmLevel=intens
+intensity=0
+loudness=1
+
+[lld:cContourSmoother]
+reader.dmLevel=intens;mfcc;mspec2log;lsp;pitch
+writer.dmLevel=lld1
+buffersize=1000
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+smaWin = 3
+; this level must grow to hold ALL the LLD of the full input
+
+// ---- delta regression of LLD ----
+[delta1:cDeltaRegression]
+reader.dmLevel=lld1
+writer.dmLevel=lld1_de
+buffersize=1000
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+deltawin=2
+blocksize=1
+
+[lld2:cContourSmoother]
+reader.dmLevel=pitchF;jitter
+writer.dmLevel=lld2
+buffersize=1000
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+; this level must grow to hold ALL the LLD of the full input
+smaWin = 3
+noZeroSma = 0
+
+// ---- delta regression of LLD ----
+[delta2:cDeltaRegression]
+reader.dmLevel=lld2
+writer.dmLevel=lld2_de
+buffersize=1000
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+deltawin=2
+blocksize=1
+
+[functOnsets:cFunctionals]
+reader.dmLevel=pitchF
+writer.dmLevel=functOnsets
+ ; frameSize and frameStep = 0 => functionals over complete input
+ ; (NOTE: buffersize of lld and lld_de levels must be large enough!!)
+frameMode = full
+frameSize = 0
+frameStep = 0
+copyInputName=0
+functNameAppend=Turn
+functionalsEnabled=Onset;Times
+//noPostEOIprocessing = 0
+Onset.threshold = 0
+;Onset.thresholdOnset = 0
+;Onset.thresholdOffset = 0
+Onset.useAbsVal = 0
+Onset.onsetPos = 0
+Onset.offsetPos = 0
+Onset.numOnsets = 1
+Onset.numOffsets = 0
+Onset.norm = segment
+Times.upleveltime25 = 0
+Times.downleveltime25 = 0
+Times.upleveltime50 = 0
+Times.downleveltime50 = 0
+Times.upleveltime75 = 0
+Times.downleveltime75 = 0
+Times.upleveltime90 = 0
+Times.downleveltime90 = 0
+Times.risetime = 0
+Times.falltime = 0
+Times.leftctime = 0
+Times.rightctime = 0
+Times.duration = 1
+Times.norm = second
+
+
+// statistical functionals
+[functL1:cFunctionals]
+reader.dmLevel=lld1;lld1_de
+writer.dmLevel=funct
+ ; frameSize and frameStep = 0 => functionals over complete input
+ ; (NOTE: buffersize of lld and lld_de levels must be large enough!!)
+frameMode = full
+frameSize=0
+frameStep=0
+functionalsEnabled=Extremes;Regression;Moments;Percentiles;Times
+Extremes.max = 0
+Extremes.min = 0
+Extremes.range = 0
+Extremes.maxpos = 1
+Extremes.minpos = 1
+Extremes.amean = 1
+Extremes.maxameandist=0
+Extremes.minameandist=0
+Extremes.norm = frame
+Regression.linregc1 = 1
+Regression.linregc2 = 1
+Regression.linregerrA = 1
+Regression.linregerrQ = 1
+Regression.qregc1 = 0
+Regression.qregc2 = 0
+Regression.qregc3 = 0
+Regression.qregerrA = 0
+Regression.qregerrQ = 0
+Regression.centroid = 0
+Regression.oldBuggyQerr = 1
+Regression.normInputs = 0
+Regression.normRegCoeff = 0
+Regression.centroidRatioLimit = 0
+Regression.doRatioLimit = 0
+Moments.doRatioLimit = 0
+Moments.variance = 0
+Moments.stddev = 1
+Moments.skewness = 1
+Moments.kurtosis = 1
+Moments.amean = 0
+Percentiles.quartiles = 1
+Percentiles.quartile1 = 0
+Percentiles.quartile2 = 0
+Percentiles.quartile3 = 0
+Percentiles.iqr = 1
+Percentiles.iqr12 = 0
+Percentiles.iqr23 = 0
+Percentiles.iqr13 = 0
+Percentiles.interp = 1
+Percentiles.percentile = 0.01;0.99
+Percentiles.pctlrange=0-1
+Times.upleveltime25 = 0
+Times.downleveltime25 = 0
+Times.upleveltime50 = 0
+Times.downleveltime50 = 0
+Times.upleveltime75 = 1
+Times.downleveltime75 = 0
+Times.upleveltime90 = 1
+Times.downleveltime90 = 0
+Times.risetime = 0
+Times.falltime = 0
+Times.leftctime = 0
+Times.rightctime = 0
+Times.duration = 0
+Times.norm = segment
+nonZeroFuncts = 0
+
+// statistical functionals
+[functL1nz:cFunctionals]
+reader.dmLevel=lld2;lld2_de
+writer.dmLevel=functNz
+ ; frameSize and frameStep = 0 => functionals over complete input
+ ; (NOTE: buffersize of lld and lld_de levels must be large enough!!)
+frameMode=full
+frameSize=0
+frameStep=0
+functionalsEnabled=Extremes;Regression;Moments;Percentiles;Times
+Extremes.max = 0
+Extremes.min = 0
+Extremes.range = 0
+Extremes.maxpos = 1
+Extremes.minpos = 1
+Extremes.amean = 1
+Extremes.maxameandist=0
+Extremes.minameandist=0
+Extremes.norm = frame
+Regression.linregc1 = 1
+Regression.linregc2 = 1
+Regression.linregerrA = 1
+Regression.linregerrQ = 1
+Regression.qregc1 = 0
+Regression.qregc2 = 0
+Regression.qregc3 = 0
+Regression.qregerrA = 0
+Regression.qregerrQ = 0
+Regression.centroid = 0
+Regression.oldBuggyQerr = 1
+Regression.normInputs = 0
+Regression.normRegCoeff = 0
+Regression.centroidRatioLimit = 0
+Regression.doRatioLimit = 0
+Moments.doRatioLimit = 0
+Moments.variance = 0
+Moments.stddev = 1
+Moments.skewness = 1
+Moments.kurtosis = 1
+Moments.amean = 0
+Percentiles.quartiles = 1
+Percentiles.quartile1 = 0
+Percentiles.quartile2 = 0
+Percentiles.quartile3 = 0
+Percentiles.iqr = 1
+Percentiles.iqr12 = 0
+Percentiles.iqr23 = 0
+Percentiles.iqr13 = 0
+Percentiles.interp = 1
+Percentiles.percentile = 0.99
+;Percentiles.pctlrange=0-1
+Times.upleveltime25 = 0
+Times.downleveltime25 = 0
+Times.upleveltime50 = 0
+Times.downleveltime50 = 0
+Times.upleveltime75 = 1
+Times.downleveltime75 = 0
+Times.upleveltime90 = 1
+Times.downleveltime90 = 0
+Times.risetime = 0
+Times.falltime = 0
+Times.leftctime = 0
+Times.rightctime = 0
+Times.duration = 0
+Times.norm = segment
+nonZeroFuncts=1
+
+;;;;;;;;; prepare features for standard output module
+
+[componentInstances:cComponentManager]
+instance[lldconcat].type=cVectorConcat
+instance[llddeconcat].type=cVectorConcat
+instance[funcconcat].type=cVectorConcat
+
+[lldconcat:cVectorConcat]
+reader.dmLevel = lld1;lld2
+writer.dmLevel = lld
+includeSingleElementFields = 1
+
+[llddeconcat:cVectorConcat]
+reader.dmLevel = lld1_de;lld2_de
+writer.dmLevel = lld_de
+includeSingleElementFields = 1
+
+[funcconcat:cVectorConcat]
+reader.dmLevel = funct;functNz;functOnsets
+writer.dmLevel = func
+includeSingleElementFields = 1
+
+\{\cm[sink{?}:include external sink]}
+
+
+
+//////---------------------- END -------------------------///////

--- a/opensmile/core/config/is09-13/IS10_paraling_core.func.conf.inc
+++ b/opensmile/core/config/is09-13/IS10_paraling_core.func.conf.inc
@@ -1,0 +1,186 @@
+
+///////////////////////////////////////////////////////////////////////////////////////
+///////// > openSMILE configuration file for IS10 features <         //////////////////
+///////// > core features : functionals <                            //////////////////
+///////// (c) 2014 by audEERING                                      //////////////////
+/////////     All rights reserved. See file COPYING for details.     //////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+
+
+// NOTE: This file is not compatible with old versions of openSMILE (< 2.1)
+// and will not give the same features (numerically) 
+// as the original IS10 features.
+// It should be preferred in new studies / designes, however, as it contains
+// some minor fixes.
+// For compatible features, use the IS10_paraling_compat.conf
+
+[componentInstances:cComponentManager]
+ ;;; functionals over FULL input (e.g. turns)
+instance[is10_functOnsets].type=cFunctionals
+instance[is10_functL1].type=cFunctionals
+instance[is10_functL1nz].type=cFunctionals
+
+[is10_functOnsets:cFunctionals]
+reader.dmLevel=is10_pitchF
+writer.dmLevel=is10_functOnsets
+\{\cm[bufferModeRbConf]}
+ ; frameSize and frameStep = 0 => functionals over complete input
+ ; (NOTE: buffersize of lld and lld_de levels must be large enough!!)
+\{\cm[frameModeFunctionalsConf{../shared/FrameModeFunctionals.conf.inc}:path to included config to set frame mode for all functionals]}
+copyInputName=0
+functNameAppend=Turn
+functionalsEnabled=Onset;Times
+//noPostEOIprocessing = 0
+Onset.threshold = 0
+;Onset.thresholdOnset = 0
+;Onset.thresholdOffset = 0
+Onset.useAbsVal = 0
+Onset.onsetPos = 0
+Onset.offsetPos = 0
+Onset.numOnsets = 0
+Onset.numOffsets = 0
+Onset.onsetRate = 1
+Onset.norm = segment
+Times.upleveltime25 = 0
+Times.downleveltime25 = 0
+Times.upleveltime50 = 0
+Times.downleveltime50 = 0
+Times.upleveltime75 = 0
+Times.downleveltime75 = 0
+Times.upleveltime90 = 0
+Times.downleveltime90 = 0
+Times.risetime = 0
+Times.falltime = 0
+Times.leftctime = 0
+Times.rightctime = 0
+Times.duration = 1
+Times.norm = second
+
+// statistical functionals
+[is10_functL1:cFunctionals]
+reader.dmLevel=is10_lld1;is10_lld1_de
+writer.dmLevel=is10_funct
+\{\cm[bufferModeRbConf]}
+ ; frameSize and frameStep = 0 => functionals over complete input
+ ; (NOTE: buffersize of lld and lld_de levels must be large enough!!)
+\{\cm[frameModeFunctionalsConf]}
+functionalsEnabled=Extremes;Regression;Moments;Percentiles;Times
+Extremes.max = 0
+Extremes.min = 0
+Extremes.range = 0
+Extremes.maxpos = 1
+Extremes.minpos = 1
+Extremes.amean = 1
+Extremes.maxameandist=0
+Extremes.minameandist=0
+Extremes.norm = frame
+Regression.linregc1 = 1
+Regression.linregc2 = 1
+Regression.linregerrA = 1
+Regression.linregerrQ = 1
+Regression.qregc1 = 0
+Regression.qregc2 = 0
+Regression.qregc3 = 0
+Regression.qregerrA = 0
+Regression.qregerrQ = 0
+Regression.centroid = 0
+Regression.oldBuggyQerr = 0
+Regression.normInputs = 0
+Regression.normRegCoeff = 0
+Moments.variance = 0
+Moments.stddev = 1
+Moments.skewness = 1
+Moments.kurtosis = 1
+Moments.amean = 0
+Percentiles.quartiles = 1
+Percentiles.quartile1 = 0
+Percentiles.quartile2 = 0
+Percentiles.quartile3 = 0
+Percentiles.iqr = 1
+Percentiles.iqr12 = 0
+Percentiles.iqr23 = 0
+Percentiles.iqr13 = 0
+Percentiles.interp = 1
+Percentiles.percentile = 0.01;0.99
+Percentiles.pctlrange=0-1
+Times.upleveltime25 = 0
+Times.downleveltime25 = 0
+Times.upleveltime50 = 0
+Times.downleveltime50 = 0
+Times.upleveltime75 = 1
+Times.downleveltime75 = 0
+Times.upleveltime90 = 1
+Times.downleveltime90 = 0
+Times.risetime = 0
+Times.falltime = 0
+Times.leftctime = 0
+Times.rightctime = 0
+Times.duration = 0
+Times.norm = segment
+nonZeroFuncts = 0
+
+// statistical functionals
+[is10_functL1nz:cFunctionals]
+reader.dmLevel=is10_lld2;is10_lld2_de
+writer.dmLevel=is10_functNz
+\{\cm[bufferModeRbConf]}
+ ; frameSize and frameStep = 0 => functionals over complete input
+ ; (NOTE: buffersize of lld and lld_de levels must be large enough!!)
+\{\cm[frameModeFunctionalsConf]}
+functionalsEnabled=Extremes;Regression;Moments;Percentiles;Times
+Extremes.max = 0
+Extremes.min = 0
+Extremes.range = 0
+Extremes.maxpos = 1
+Extremes.minpos = 1
+Extremes.amean = 1
+Extremes.maxameandist=0
+Extremes.minameandist=0
+Extremes.norm = frame
+Regression.linregc1 = 1
+Regression.linregc2 = 1
+Regression.linregerrA = 1
+Regression.linregerrQ = 1
+Regression.qregc1 = 0
+Regression.qregc2 = 0
+Regression.qregc3 = 0
+Regression.qregerrA = 0
+Regression.qregerrQ = 0
+Regression.centroid = 0
+Regression.oldBuggyQerr = 0
+Regression.normInputs = 0
+Regression.normRegCoeff = 0
+Moments.variance = 0
+Moments.stddev = 1
+Moments.skewness = 1
+Moments.kurtosis = 1
+Moments.amean = 0
+Percentiles.quartiles = 1
+Percentiles.quartile1 = 0
+Percentiles.quartile2 = 0
+Percentiles.quartile3 = 0
+Percentiles.iqr = 1
+Percentiles.iqr12 = 0
+Percentiles.iqr23 = 0
+Percentiles.iqr13 = 0
+Percentiles.interp = 1
+Percentiles.percentile = 0.99
+;Percentiles.pctlrange=0-1
+Times.upleveltime25 = 0
+Times.downleveltime25 = 0
+Times.upleveltime50 = 0
+Times.downleveltime50 = 0
+Times.upleveltime75 = 1
+Times.downleveltime75 = 0
+Times.upleveltime90 = 1
+Times.downleveltime90 = 0
+Times.risetime = 0
+Times.falltime = 0
+Times.leftctime = 0
+Times.rightctime = 0
+Times.duration = 0
+Times.norm = segment
+nonZeroFuncts=1
+
+
+//////---------------------- END -------------------------///////

--- a/opensmile/core/config/is09-13/IS10_paraling_core.lld.conf.inc
+++ b/opensmile/core/config/is09-13/IS10_paraling_core.lld.conf.inc
@@ -1,0 +1,299 @@
+
+///////////////////////////////////////////////////////////////////////////////////////
+///////// > openSMILE configuration file for IS10 features <         //////////////////
+/////////                                                            //////////////////
+///////// (c) 2014 by audEERING                                      //////////////////
+/////////     All rights reserved. See file COPYING for details.     //////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+
+
+// NOTE: This file is not compatible with old versions of openSMILE (< 2.1)
+// and will not give the same features (numerically) 
+// as the original IS10 features.
+// It should be preferred in new studies / designes, however, as it contains
+// some minor fixes.
+// For compatible features, use the IS10_paraling_compat.conf
+
+[componentInstances:cComponentManager]
+instance[is10_fr40].type=cFramer
+  ;; 40 ms frames features
+instance[is10_w40].type=cWindower
+instance[is10_fft40].type=cTransformFFT
+instance[is10_fftmagphase40].type=cFFTmagphase
+instance[is10_scale].type=cSpecScale
+instance[is10_pitchShs].type=cPitchShs
+instance[is10_pitchSmooth].type=cPitchSmoother
+instance[is10_pitchJitter].type=cPitchJitter
+instance[is10_pitchSmooth2].type=cPitchSmoother
+instance[is10_res].type=cSpecResample
+ ;;; 25 ms frames features:
+instance[is10_fr25].type=cFramer
+instance[is10_pe].type=cVectorPreemphasis
+instance[is10_win].type=cWindower
+instance[is10_fft].type=cTransformFFT
+instance[is10_fftmagphase].type=cFFTmagphase
+ ; mfcc
+instance[is10_mspec].type=cMelspec
+instance[is10_mfcc].type=cMfcc
+ ; log mel frequency bands (mfb)
+instance[is10_mspec2].type=cMelspec
+instance[is10_vo].type=cVectorOperation
+instance[is10_lpc].type=cLpc
+ ; Line Spectral Frequencies
+instance[is10_lsp].type=cLsp
+ ; Loudness (narrow-band approximation)
+instance[is10_intens].type=cIntensity
+ ;;; all LLD concattenated and smoothed using a moving average filter
+instance[is10_lld].type=cContourSmoother
+instance[is10_lld2].type=cContourSmoother
+ ; delta coefficients of LLD
+instance[is10_delta1].type=cDeltaRegression
+instance[is10_delta2].type=cDeltaRegression
+
+
+[is10_fr40:cFramer]
+reader.dmLevel=wave
+writer.dmLevel=is10_frames40
+\{\cm[bufferModeRbConf{../shared/BufferModeRb.conf.inc}:path to included config to set the buffer mode for the standard ringbuffer levels]}
+frameMode = fixed
+frameSize = 0.060
+frameStep = 0.010
+frameCenterSpecial = left
+noPostEOIprocessing = 1
+
+[is10_w40:cWindower]
+reader.dmLevel=is10_frames40
+writer.dmLevel=is10_win40frame
+winFunc = gauss
+sigma = 0.25
+gain = 1.0
+
+[is10_fft40:cTransformFFT]
+reader.dmLevel=is10_win40frame
+writer.dmLevel=is10_fftc40
+
+[is10_fftmagphase40:cFFTmagphase]
+reader.dmLevel=is10_fftc40
+writer.dmLevel=is10_fftmag40
+magnitude = 1
+phase = 0
+
+[is10_scale:cSpecScale]
+reader.dmLevel=is10_fftmag40
+writer.dmLevel=is10_hps
+scale=octave
+sourceScale = lin
+specSmooth = 0
+auditoryWeighting = 0
+specEnhance = 0
+minF = 20
+maxF = -1
+nPointsTarget = 0
+specSmooth = 1
+specEnhance = 1
+auditoryWeighting = 1
+interpMethod = spline
+
+[is10_pitchShs:cPitchShs]
+reader.dmLevel=is10_hps
+writer.dmLevel=is10_pitchShs
+inputFieldSearch = fftMag_octScale
+F0raw = 0
+voicingClip = 0
+voicingC1=0
+scores=1
+voicing=1
+nCandidates = 6
+octaveCorrection = 0
+greedyPeakAlgo = 1
+compressionFactor = 0.85
+nHarmonics = 15
+voicingCutoff = 0.70
+maxPitch = 620
+minPitch = 52
+
+[is10_pitchSmooth:cPitchSmoother]
+reader.dmLevel=is10_pitchShs
+writer.dmLevel=is10_pitch
+F0raw = 0
+F0final = 0
+F0finalEnv = 1
+voicingFinalUnclipped = 1
+medianFilter0 = 0
+postSmoothingMethod = simple
+;simple
+octaveCorrection = 0
+writer.levelconf.nT=10
+;writer.levelconf.noHang=2
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+
+[is10_pitchSmooth2:cPitchSmoother]
+reader.dmLevel=is10_pitchShs
+writer.dmLevel=is10_pitchF
+F0raw = 0
+F0final = 1
+F0finalEnv = 0
+voicingFinalUnclipped = 0
+medianFilter0 = 0
+postSmoothingMethod = simple
+octaveCorrection = 0
+writer.levelconf.nT=10
+;writer.levelconf.noHang=2
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+
+ ;;;; default (template) configuration section for component 'cPitchJitter' ;;;;
+[is10_pitchJitter:cPitchJitter]
+reader.dmLevel = wave
+writer.dmLevel = is10_jitter
+\{\cm[bufferModeRbLagConf{../shared/BufferModeRb.conf.inc}:path to included config to set the buffer mode for levels which will be joint with Viterbi smoothed -lagged- F0]}
+copyInputName = 1
+F0reader.dmLevel = is10_pitchF
+F0field = F0final
+searchRangeRel = 0.200000
+jitterLocal = 1
+jitterDDP = 1
+jitterLocalEnv = 0
+jitterDDPEnv = 0
+shimmerLocal = 1
+shimmerLocalEnv = 0
+onlyVoiced = 0
+;periodLengths = 0
+;periodStarts = 0
+inputMaxDelaySec = 1
+usePeakToPeakPeriodLength = 0
+shimmerUseRmsAmplitude = 0
+minCC = 0.5
+minNumPeriods = 2
+
+[is10_fr25:cFramer]
+reader.dmLevel=wave
+writer.dmLevel=is10_frames
+\{\cm[bufferModeRbConf]}
+frameSize = 0.025
+frameStep = 0.010
+frameCenterSpecial = left
+
+[is10_pe:cVectorPreemphasis]
+reader.dmLevel=is10_frames
+writer.dmLevel=is10_framespe
+k=0.97
+
+[is10_win:cWindower]
+reader.dmLevel=is10_framespe
+writer.dmLevel=is10_winframe
+winFunc = ham
+gain = 1.0
+
+[is10_fft:cTransformFFT]
+reader.dmLevel=is10_winframe
+writer.dmLevel=is10_fftc
+
+[is10_fftmagphase:cFFTmagphase]
+reader.dmLevel=is10_fftc
+writer.dmLevel=is10_fftmag
+magnitude = 1
+phase = 0
+
+[is10_mspec:cMelspec]
+reader.dmLevel=is10_fftmag
+writer.dmLevel=is10_mspec1
+htkcompatible = 0
+usePower = 1
+lofreq = 20
+hifreq = 8000
+nBands=26
+specScale = mel
+bwMethod = lr
+
+[is10_mfcc:cMfcc]
+reader.dmLevel = is10_mspec1
+writer.dmLevel = is10_mfcc
+htkcompatible = 0
+firstMfcc=0
+lastMfcc=14
+cepLifter=22
+copyInputName = 0
+
+[is10_mspec2:cMelspec]
+reader.dmLevel=is10_fftmag
+writer.dmLevel=is10_mspec2
+htkcompatible = 0
+usePower = 1
+lofreq = 20
+hifreq = 6500
+nBands=8
+specScale = mel
+bwMethod = lr
+
+[is10_vo:cVectorOperation]
+reader.dmLevel=is10_mspec2
+writer.dmLevel=is10_mspec2log
+operation = log
+copyInputName = 0
+nameAppend=logMelFreqBand
+
+[is10_res:cSpecResample]
+reader.dmLevel=is10_fftc
+writer.dmLevel=is10_outpR
+targetFs = 11000
+
+[is10_lpc:cLpc]
+;reader.dmLevel=framespe
+reader.dmLevel=is10_outpR
+writer.dmLevel=is10_lpc
+p=8
+method = acf
+saveLPCoeff = 1
+lpGain = 0
+saveRefCoeff = 0
+residual = 0
+forwardFilter = 0
+lpSpectrum = 0
+
+[is10_lsp:cLsp]
+reader.dmLevel=is10_lpc
+writer.dmLevel=is10_lsp
+
+[is10_intens:cIntensity]
+reader.dmLevel=is10_frames
+writer.dmLevel=is10_intens
+intensity=0
+loudness=1
+
+[is10_lld:cContourSmoother]
+reader.dmLevel=is10_intens;is10_mfcc;is10_mspec2log;is10_lsp;is10_pitch
+writer.dmLevel=is10_lld1
+\{\cm[bufferModeConf{../shared/BufferMode.conf.inc}:path to included config to set the buffer mode for the levels before the functionals]}
+smaWin = 3
+; this level must grow to hold ALL the LLD of the full input
+
+// ---- delta regression of LLD ----
+[is10_delta1:cDeltaRegression]
+reader.dmLevel=is10_lld1
+writer.dmLevel=is10_lld1_de
+\{\cm[bufferModeConf]}
+deltawin=2
+blocksize=1
+
+[is10_lld2:cContourSmoother]
+reader.dmLevel=is10_pitchF;is10_jitter
+writer.dmLevel=is10_lld2
+\{\cm[bufferModeConf]}
+; this level must grow to hold ALL the LLD of the full input
+smaWin = 3
+noZeroSma = 1
+
+// ---- delta regression of LLD ----
+[is10_delta2:cDeltaRegression]
+reader.dmLevel=is10_lld2
+writer.dmLevel=is10_lld2_de
+\{\cm[bufferModeConf]}
+deltawin=2
+blocksize=1
+onlyInSegments = 1
+zeroSegBound = 1
+
+
+//////---------------------- END -------------------------///////

--- a/opensmile/core/config/is09-13/IS11_speaker_state.conf
+++ b/opensmile/core/config/is09-13/IS11_speaker_state.conf
@@ -1,0 +1,806 @@
+///////////////////////////////////////////////////////////////////////////////////////
+///////// > openSMILE configuration file for IS11 features <         //////////////////
+/////////                                                            //////////////////
+///////// (c) 2014 by audEERING                                      //////////////////
+/////////     All rights reserved. See file COPYING for details.     //////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+
+
+// 
+// Usage:
+// SMILExtract -C IS11.conf -I input.wav -O output.arff
+// -- append features for input.wav to output.arff (create if necessary)
+//
+
+
+;;;;;;; component list ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+[componentInstances:cComponentManager]
+instance[dataMemory].type=cDataMemory
+printLevelStats=0
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;; main section ;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+\{\cm[source{?}:include external source]}
+;;;;;;;;;;;;;;;;;;;;;;
+
+[componentInstances:cComponentManager]
+instance[frame60].type=cFramer
+instance[win60].type=cWindower
+instance[fft60].type=cTransformFFT
+instance[fftmp60].type=cFFTmagphase
+
+[frame60:cFramer]
+reader.dmLevel=wave
+writer.dmLevel=frame60
+frameSize = 0.060
+frameStep = 0.010
+frameCenterSpecial = left
+
+
+[win60:cWindower]
+reader.dmLevel=frame60
+writer.dmLevel=winG60
+winFunc=gauss
+gain=1.0
+sigma=0.4
+
+[fft60:cTransformFFT]
+reader.dmLevel=winG60
+writer.dmLevel=fftcG60
+ ; for compatibility with 2.2.0 and older versions
+zeroPadSymmetric = 0
+
+[fftmp60:cFFTmagphase]
+reader.dmLevel=fftcG60
+writer.dmLevel=fftmagG60
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+[componentInstances:cComponentManager]
+instance[frame25].type=cFramer
+instance[pe25].type=cVectorPreemphasis
+instance[win25].type=cWindower
+instance[fft25].type=cTransformFFT
+instance[fftmp25].type=cFFTmagphase
+
+[frame25:cFramer]
+reader.dmLevel=wave
+writer.dmLevel=frame25
+frameSize = 0.020
+frameStep = 0.010
+frameCenterSpecial = left
+
+[pe25:cVectorPreemphasis]
+reader.dmLevel=frame25
+writer.dmLevel=frame25pe
+k=0.97
+de=0
+
+[win25:cWindower]
+reader.dmLevel=frame25
+writer.dmLevel=winH25
+winFunc=hamming
+
+[fft25:cTransformFFT]
+reader.dmLevel=winH25
+writer.dmLevel=fftcH25
+ ; for compatibility with 2.2.0 and older versions
+zeroPadSymmetric = 0
+
+[fftmp25:cFFTmagphase]
+reader.dmLevel=fftcH25
+writer.dmLevel=fftmagH25
+
+
+
+;;;;;;;;;;;;;;;;;;;; HPS pitch
+
+[componentInstances:cComponentManager]
+instance[scale].type=cSpecScale
+instance[shs].type=cPitchShs
+instance[pitchSmooth].type=cPitchSmoother
+instance[pitchSmooth2].type=cPitchSmoother
+
+
+[scale:cSpecScale]
+reader.dmLevel=fftmagG60
+writer.dmLevel=hpsG60
+copyInputName = 1
+processArrayFields = 0
+scale=octave
+sourceScale = lin
+// logScaleBase = 2
+// logSourceScaleBase = 2
+// firstNote = 55
+interpMethod = spline
+minF = 25
+maxF = -1
+nPointsTarget = 0
+specSmooth = 1
+specEnhance = 1
+auditoryWeighting = 1 
+
+[shs:cPitchShs]
+reader.dmLevel=hpsG60
+writer.dmLevel=pitchShsG60
+copyInputName = 1
+processArrayFields = 0
+maxPitch = 620
+minPitch = 52
+nCandidates = 4
+scores = 1
+voicing = 1
+F0C1 = 0
+voicingC1 = 0
+F0raw = 1
+voicingClip = 1
+voicingCutoff = 0.700000
+inputFieldSearch = Mag_octScale
+octaveCorrection = 0
+nHarmonics = 15
+compressionFactor = 0.850000
+
+[pitchSmooth:cPitchSmoother]
+reader.dmLevel=pitchShsG60
+writer.dmLevel=pitchG60
+copyInputName = 1
+processArrayFields = 0
+medianFilter0 = 0
+postSmoothing = 0
+postSmoothingMethod = simple
+ ; note: octave correction is too agressive, thus we disable it..
+octaveCorrection = 0
+F0final = 1
+F0finalEnv = 0
+no0f0 = 0
+voicingFinalClipped = 0
+voicingFinalUnclipped = 1
+F0raw = 0
+voicingC1 = 0
+voicingClip = 0
+
+[pitchSmooth2:cPitchSmoother]
+reader.dmLevel=pitchShsG60
+writer.dmLevel=pitchF
+F0raw = 0
+F0final = 1
+F0finalEnv = 0
+voicingFinalUnclipped = 0
+medianFilter0 = 0
+postSmoothingMethod = simple
+octaveCorrection = 0
+
+
+;;;;;;;;;;;;;;;;;;; VQ
+
+[componentInstances:cComponentManager]
+;instance[acf].type=cAcf
+;instance[hnr].type=cHnr
+instance[pitchJitter].type=cPitchJitter
+
+
+[pitchJitter:cPitchJitter]
+reader.dmLevel = wave
+writer.dmLevel = jitterShimmer
+// nameAppend =
+copyInputName = 1
+F0reader.dmLevel = pitchF
+F0field = F0final
+searchRangeRel = 0.250000
+jitterLocal = 1
+jitterDDP = 1
+jitterLocalEnv = 0
+jitterDDPEnv = 0
+shimmerLocal = 1
+shimmerLocalEnv = 0
+onlyVoiced = 0
+;periodLengths = 0
+;periodStarts = 0
+useBrokenJitterThresh = 1
+
+;;;;;;;;;;;;;;;;;;;;; Energy / loudness
+
+
+[componentInstances:cComponentManager]
+instance[energy].type=cEnergy
+instance[melspec1].type=cMelspec
+instance[audspec].type=cPlp
+instance[audspecRasta].type=cPlp
+instance[audspecSum].type=cVectorOperation
+instance[audspecRastaSum].type=cVectorOperation
+
+
+[energy:cEnergy]
+reader.dmLevel = frame25
+writer.dmLevel = energy
+log=0
+rms=1
+
+
+[melspec1:cMelspec]
+reader.dmLevel=fftmagH25
+writer.dmLevel=melspec1
+; htk compatible sample value scaling
+htkcompatible = 0
+nBands = 26
+; use power spectrum instead of magnitude spectrum
+usePower = 1
+lofreq = 20
+hifreq = 8000
+specScale = mel
+
+; perform auditory weighting of spectrum
+[audspec:cPlp]
+reader.dmLevel=melspec1
+writer.dmLevel=audspec
+firstCC = 0
+lpOrder = 5
+cepLifter = 22
+compression = 0.33
+htkcompatible = 0 
+doIDFT = 0
+doLpToCeps = 0
+doLP = 0
+doInvLog = 0
+doAud = 1
+doLog = 0
+newRASTA=0
+RASTA=0
+
+; perform RASTA style filtering of auditory spectra
+[audspecRasta:cPlp]
+reader.dmLevel=melspec1
+writer.dmLevel=audspecRasta
+nameAppend = Rfilt
+firstCC = 0
+lpOrder = 5
+cepLifter = 22
+compression = 0.33
+htkcompatible = 0 
+doIDFT = 0
+doLpToCeps = 0
+doLP = 0
+doInvLog = 0
+doAud = 1
+doLog = 0
+newRASTA=1
+RASTA=0
+
+[audspecSum:cVectorOperation]
+reader.dmLevel = audspec
+writer.dmLevel = audspecSum
+// nameAppend = 
+copyInputName = 1
+processArrayFields = 0
+operation = ll1
+nameBase = audspec
+
+[audspecRastaSum:cVectorOperation]
+reader.dmLevel = audspecRasta
+writer.dmLevel = audspecRastaSum
+// nameAppend = 
+copyInputName = 1
+processArrayFields = 0
+operation = ll1
+nameBase = audspecRasta
+
+;;;;;;;;;;;;;;; spectral
+
+[componentInstances:cComponentManager]
+instance[spectral].type=cSpectral
+
+
+[spectral:cSpectral]
+reader.dmLevel=fftmagH25
+writer.dmLevel=spectral
+bands[0]=25-650
+bands[1]=1000-4000
+rollOff[0] = 0.25
+rollOff[1] = 0.50
+rollOff[2] = 0.75
+rollOff[3] = 0.90
+flux=1
+centroid=0
+maxPos=0
+minPos=0
+entropy=1
+variance=1
+skewness=1
+kurtosis=1
+slope=1
+
+
+;;;;;;;;;;;;;;; mfcc
+
+[componentInstances:cComponentManager]
+instance[melspecMfcc].type=cMelspec
+instance[mfcc].type=cMfcc
+
+[melspecMfcc:cMelspec]
+reader.dmLevel=fftmagH25
+writer.dmLevel=melspecMfcc
+copyInputName = 1
+processArrayFields = 1
+; htk compatible sample value scaling
+htkcompatible = 1
+nBands = 26s
+; use power spectrum instead of magnitude spectrum
+usePower = 1
+lofreq = 20
+hifreq = 8000
+specScale = mel
+inverse = 0
+
+[mfcc:cMfcc]
+reader.dmLevel=melspecMfcc
+writer.dmLevel=mfcc1_12
+copyInputName = 1
+processArrayFields = 1
+firstMfcc = 1
+lastMfcc  = 12
+cepLifter = 22.0
+htkcompatible = 1
+
+
+;;;;;;;;;;;;;;;;  zcr
+
+[componentInstances:cComponentManager]
+instance[mzcr].type=cMZcr
+
+[mzcr:cMZcr]
+reader.dmLevel = frame25
+writer.dmLevel = zcr
+copyInputName = 1
+processArrayFields = 1
+zcr = 1
+mcr = 0
+amax = 0
+maxmin = 0
+dc = 0
+
+
+
+;;;;;;;;;;;;;;;;;;;; smoothing
+
+[componentInstances:cComponentManager]
+instance[smoNz].type=cContourSmoother
+instance[smoA].type=cContourSmoother
+instance[smoB].type=cContourSmoother
+instance[f0sel].type=cDataSelector
+
+[smoNz:cContourSmoother]
+reader.dmLevel = pitchG60;jitterShimmer
+writer.dmLevel = lld_nzsmo
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+nameAppend = sma
+copyInputName = 1
+noPostEOIprocessing = 0
+smaWin = 3
+noZeroSma = 1
+
+[f0sel:cDataSelector]
+reader.dmLevel = lld_nzsmo
+writer.dmLevel = lld_f0_nzsmo
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+nameAppend = ff0
+selected = F0final_sma
+
+[smoA:cContourSmoother]
+reader.dmLevel = audspecSum;audspecRastaSum;energy;zcr
+writer.dmLevel = lldA_smo
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+nameAppend = sma
+copyInputName = 1
+noPostEOIprocessing = 0
+smaWin = 3
+
+[smoB:cContourSmoother]
+reader.dmLevel = audspecRasta;spectral;mfcc1_12
+writer.dmLevel = lldB_smo
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+nameAppend = sma
+copyInputName = 1
+noPostEOIprocessing = 0
+smaWin = 3
+
+;;;;;;;;; deltas
+[componentInstances:cComponentManager]
+instance[deNz].type=cDeltaRegression
+instance[deA].type=cDeltaRegression
+instance[deB].type=cDeltaRegression
+instance[def0sel].type=cDeltaRegression
+
+[deNz:cDeltaRegression]
+reader.dmLevel = lld_nzsmo
+writer.dmLevel = lld_nzsmo_de
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+
+[deA:cDeltaRegression]
+reader.dmLevel = lldA_smo
+writer.dmLevel = lldA_smo_de
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+
+[deB:cDeltaRegression]
+reader.dmLevel = lldB_smo
+writer.dmLevel = lldB_smo_de
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+
+[def0sel:cDeltaRegression]
+reader.dmLevel = lld_f0_nzsmo
+writer.dmLevel = lld_f0_nzsmo_de
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+
+;;;;;;;;; functionals / statistics
+
+
+[componentInstances:cComponentManager]
+instance[functionalsA].type=cFunctionals
+instance[functionalsB].type=cFunctionals
+instance[functionalsF0].type=cFunctionals
+instance[functionalsNz].type=cFunctionals
+
+
+; functionals for energy related lld
+[functionalsA:cFunctionals]
+reader.dmLevel = lldA_smo;lldA_smo_de
+writer.dmLevel = functionalsA
+// nameAppend = 
+copyInputName = 1
+frameMode = full
+frameSize = 0
+frameStep = 0
+frameCenterSpecial = left
+
+functionalsEnabled = Percentiles ; Means ; Moments ; Peaks ; Segments ; Regression ; Times ;  Lpc
+
+Means.amean = 1
+Means.absmean = 0
+Means.qmean = 0
+Means.nzamean = 0
+Means.nzabsmean = 0
+Means.nzqmean = 0
+Means.nzgmean = 0
+Means.nnz = 0
+Means.norm = frames
+
+Peaks.numPeaks = 0
+Peaks.meanPeakDist = 1
+Peaks.peakMean = 1
+Peaks.peakMeanMeanDist = 1
+Peaks.peakDistStddev = 1
+Peaks.norm = second
+
+Segments.maxNumSeg = 100
+Segments.segmentationAlgorithm = relTh
+Segments.thresholds = 0.25
+Segments.numSegments = 0
+Segments.meanSegLen = 1
+Segments.maxSegLen = 1
+Segments.minSegLen = 1
+Segments.segLenStddev = 1
+Segments.norm = second
+
+Moments.variance = 0
+Moments.stddev = 1
+Moments.skewness = 1
+Moments.kurtosis = 1
+Moments.amean = 0
+Moments.doRatioLimit = 0
+
+Percentiles.quartiles = 1
+Percentiles.iqr = 1
+Percentiles.percentile[0] = 0.01
+Percentiles.percentile[1] = 0.99
+Percentiles.pctlrange[0] = 0-1
+Percentiles.interp = 1
+
+Regression.linregc1 = 1
+Regression.linregc2 = 0
+Regression.linregerrA = 0
+Regression.linregerrQ = 1
+Regression.qregc1 = 1
+Regression.qregc2 = 1
+Regression.qregc3 = 0
+Regression.qregerrA = 0
+Regression.qregerrQ = 1
+Regression.oldBuggyQerr = 0
+Regression.centroid = 1
+Regression.normRegCoeff = 0
+Regression.doRatioLimit = 0
+Regression.centroidRatioLimit = 0
+Regression.centroidUseAbsValues = 0
+
+Times.upleveltime25 = 0
+Times.downleveltime25 = 1
+Times.upleveltime50 = 0
+Times.downleveltime50 = 0
+Times.upleveltime75 = 0
+Times.downleveltime75 = 0
+Times.upleveltime90 = 1
+Times.downleveltime90 = 0
+Times.risetime = 1
+Times.falltime = 1
+Times.leftctime = 0
+Times.rightctime = 0
+Times.duration = 0
+Times.buggySecNorm = 0
+Times.norm = segment
+
+Lpc.lpGain = 1
+Lpc.lpc = 1
+Lpc.firstCoeff = 0
+Lpc.order = 5
+
+nonZeroFuncts = 0
+masterTimeNorm = segment
+
+
+
+; functionals for spectrum related lld
+[functionalsB:cFunctionals]
+reader.dmLevel = lldB_smo;lldB_smo_de
+writer.dmLevel = functionalsB
+// nameAppend = 
+copyInputName = 1
+frameMode = full
+frameSize = 0
+frameStep = 0
+frameCenterSpecial = left
+
+functionalsEnabled = Percentiles ; Means ; Moments ; Peaks ; Segments ; Regression ; Times ;  Lpc
+
+Means.amean = 1
+Means.absmean = 0
+Means.qmean = 0
+Means.nzamean = 0
+Means.nzabsmean = 0
+Means.nzqmean = 0
+Means.nzgmean = 0
+Means.nnz = 0
+Means.norm = frames
+
+Peaks.numPeaks = 0
+Peaks.meanPeakDist = 1
+Peaks.peakMean = 1
+Peaks.peakMeanMeanDist = 1
+Peaks.peakDistStddev = 1
+Peaks.norm = second
+
+Segments.maxNumSeg = 100
+Segments.segmentationAlgorithm = relTh
+Segments.thresholds = 0.25 ; 0.75
+Segments.rangeRelThreshold = 0.200000
+Segments.numSegments = 0
+Segments.meanSegLen = 1
+Segments.maxSegLen = 1
+Segments.minSegLen = 1
+Segments.segLenStddev = 1
+Segments.norm = second
+
+Moments.variance = 0
+Moments.stddev = 1
+Moments.skewness = 1
+Moments.kurtosis = 1
+Moments.amean = 0
+Moments.doRatioLimit = 0
+
+Percentiles.quartiles = 1
+Percentiles.iqr = 1
+Percentiles.percentile[0] = 0.01
+Percentiles.percentile[1] = 0.99
+Percentiles.pctlrange[0] = 0-1
+Percentiles.interp = 1
+
+Regression.linregc1 = 1
+Regression.linregc2 = 0
+Regression.linregerrA = 0
+Regression.linregerrQ = 1
+Regression.qregc1 = 1
+Regression.qregc2 = 1
+Regression.qregc3 = 0
+Regression.qregerrA = 0
+Regression.qregerrQ = 1
+Regression.oldBuggyQerr = 0
+Regression.centroid = 1
+Regression.normRegCoeff = 0
+Regression.doRatioLimit = 0
+Regression.centroidRatioLimit = 0
+Regression.centroidUseAbsValues = 0
+
+Times.upleveltime25 = 0
+Times.downleveltime25 = 1
+Times.upleveltime50 = 0
+Times.downleveltime50 = 0
+Times.upleveltime75 = 0
+Times.downleveltime75 = 0
+Times.upleveltime90 = 1
+Times.downleveltime90 = 0
+Times.risetime = 1
+Times.falltime = 1
+Times.leftctime = 0
+Times.rightctime = 0
+Times.duration = 0
+Times.buggySecNorm = 0
+Times.norm = segment
+
+Lpc.lpGain = 1
+Lpc.lpc = 1
+Lpc.firstCoeff = 0
+Lpc.order = 5
+
+nonZeroFuncts = 0
+masterTimeNorm = segment
+
+
+
+; functionals for pitch onsets/offsets
+[functionalsF0:cFunctionals]
+reader.dmLevel = lld_f0_nzsmo;lld_f0_nzsmo_de
+writer.dmLevel = functionalsF0
+copyInputName = 1
+frameMode = full
+frameSize = 0
+frameStep = 0
+frameCenterSpecial = left
+
+functionalsEnabled = Means ; Segments ; Times
+
+Means.amean = 0
+Means.absmean = 0
+Means.qmean = 0
+Means.nzamean = 0
+Means.nzabsmean = 0
+Means.nzqmean = 0
+Means.nzgmean = 0
+Means.nnz = 1
+Means.norm = segment
+
+Segments.maxNumSeg = 100
+Segments.segmentationAlgorithm = nonX
+Segments.X = 0.0
+Segments.numSegments = 0
+Segments.meanSegLen = 1
+Segments.maxSegLen = 1
+Segments.minSegLen = 1
+Segments.segLenStddev = 1
+Segments.norm = second
+
+Times.upleveltime25 = 0
+Times.downleveltime25 = 0
+Times.upleveltime50 = 0
+Times.downleveltime50 = 0
+Times.upleveltime75 = 0
+Times.downleveltime75 = 0
+Times.upleveltime90 = 0
+Times.downleveltime90 = 0
+Times.risetime = 0
+Times.falltime = 0
+Times.leftctime = 0
+Times.rightctime = 0
+Times.duration = 1
+Times.buggySecNorm = 0
+Times.norm = second
+
+nonZeroFuncts = 0
+masterTimeNorm = segment
+
+
+
+; functionals for pitch and vq related lld in voiced regions
+[functionalsNz:cFunctionals]
+reader.dmLevel = lld_nzsmo;lld_nzsmo_de
+writer.dmLevel = functionalsNz
+copyInputName = 1
+frameMode = full
+frameSize = 0
+frameStep = 0
+frameCenterSpecial = left
+
+functionalsEnabled = Percentiles ; Means ; Moments ; Peaks ; Regression ; Times ; Lpc
+
+Means.amean = 1
+Means.absmean = 0
+Means.qmean = 1
+Means.nzamean = 0
+Means.nzabsmean = 0
+Means.nzqmean = 0
+Means.nzgmean = 0
+Means.nnz = 0
+Means.norm = frames
+
+Peaks.numPeaks = 0
+Peaks.meanPeakDist = 1
+Peaks.peakMean = 1
+Peaks.peakMeanMeanDist = 1
+Peaks.peakDistStddev = 1
+Peaks.norm = second
+
+Moments.variance = 0
+Moments.stddev = 1
+Moments.skewness = 1
+Moments.kurtosis = 1
+Moments.amean = 0
+Moments.doRatioLimit = 0
+
+Percentiles.quartiles = 1
+Percentiles.iqr = 1
+Percentiles.percentile[0] = 0.01
+Percentiles.percentile[1] = 0.99
+Percentiles.pctlrange[0] = 0-1
+Percentiles.interp = 1
+
+Regression.linregc1 = 1
+Regression.linregc2 = 0
+Regression.linregerrA = 0
+Regression.linregerrQ = 1
+Regression.qregc1 = 1
+Regression.qregc2 = 1
+Regression.qregc3 = 0
+Regression.qregerrA = 0
+Regression.qregerrQ = 1
+Regression.oldBuggyQerr = 0
+Regression.centroid = 1
+Regression.normRegCoeff = 0
+Regression.centroidRatioLimit = 0
+Regression.centroidUseAbsValues = 0
+Regression.doRatioLimit = 0
+
+Times.upleveltime25 = 0
+Times.downleveltime25 = 1
+Times.upleveltime50 = 0
+Times.downleveltime50 = 0
+Times.upleveltime75 = 0
+Times.downleveltime75 = 0
+Times.upleveltime90 = 1
+Times.downleveltime90 = 0
+Times.risetime = 1
+Times.falltime = 1
+Times.leftctime = 1
+Times.rightctime = 1
+Times.duration = 0
+Times.buggySecNorm = 0
+Times.norm = segment
+
+Lpc.lpGain = 1
+Lpc.lpc = 1
+Lpc.firstCoeff = 0
+Lpc.order = 5
+
+nonZeroFuncts = 1
+masterTimeNorm = segment
+
+;;;;;;;;; prepare features for standard output module
+
+[componentInstances:cComponentManager]
+instance[lldconcat].type=cVectorConcat
+instance[llddeconcat].type=cVectorConcat
+instance[funcconcat].type=cVectorConcat
+
+[lldconcat:cVectorConcat]
+reader.dmLevel = lld_nzsmo;lldA_smo;lldB_smo
+writer.dmLevel = lld
+includeSingleElementFields = 1
+
+[llddeconcat:cVectorConcat]
+reader.dmLevel = lld_nzsmo_de;lldA_smo_de;lldB_smo_de
+writer.dmLevel = lld_de
+includeSingleElementFields = 1
+
+[funcconcat:cVectorConcat]
+reader.dmLevel = functionalsA;functionalsB;functionalsNz;functionalsF0
+writer.dmLevel = func
+includeSingleElementFields = 1
+
+\{\cm[sink{?}:include external sink]}
+

--- a/opensmile/core/config/is09-13/IS12_speaker_trait_compat.conf
+++ b/opensmile/core/config/is09-13/IS12_speaker_trait_compat.conf
@@ -1,0 +1,864 @@
+///////////////////////////////////////////////////////////////////////////////////////
+///////// > openSMILE configuration file for IS12 challenge <        //////////////////
+/////////   This file produces backwards compatible features         //////////////////
+/////////   (to version 1.x) with openSMILE version 2.1              //////////////////
+/////////                                                            //////////////////
+///////// (c) 2013-2016 by audEERING                                 //////////////////
+/////////     All rights reserved. See file COPYING for details.     //////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+
+
+
+
+;;;;;;; component list ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+[componentInstances:cComponentManager]
+instance[dataMemory].type=cDataMemory
+printLevelStats=0
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;; main section ;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+\{\cm[source{?}:include external source]}
+
+;;;;;;;;;;;;;;;;;;;;;;
+
+[componentInstances:cComponentManager]
+instance[frame60].type=cFramer
+instance[win60].type=cWindower
+instance[fft60].type=cTransformFFT
+instance[fftmp60].type=cFFTmagphase
+
+[frame60:cFramer]
+reader.dmLevel=wave
+writer.dmLevel=frame60
+frameSize = 0.060
+frameStep = 0.010
+frameCenterSpecial = left
+
+
+[win60:cWindower]
+reader.dmLevel=frame60
+writer.dmLevel=winG60
+winFunc=gauss
+gain=1.0
+sigma=0.4
+
+[fft60:cTransformFFT]
+reader.dmLevel=winG60
+writer.dmLevel=fftcG60
+ ; for compatibility with 2.2.0 and older versions
+zeroPadSymmetric = 0
+
+[fftmp60:cFFTmagphase]
+reader.dmLevel=fftcG60
+writer.dmLevel=fftmagG60
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+[componentInstances:cComponentManager]
+instance[frame25].type=cFramer
+instance[pe25].type=cVectorPreemphasis
+instance[win25].type=cWindower
+instance[fft25].type=cTransformFFT
+instance[fftmp25].type=cFFTmagphase
+
+[frame25:cFramer]
+reader.dmLevel=wave
+writer.dmLevel=frame25
+frameSize = 0.020
+frameStep = 0.010
+frameCenterSpecial = left
+
+[pe25:cVectorPreemphasis]
+reader.dmLevel=frame25
+writer.dmLevel=frame25pe
+k=0.97
+de=0
+
+[win25:cWindower]
+reader.dmLevel=frame25
+writer.dmLevel=winH25
+winFunc=hamming
+
+[fft25:cTransformFFT]
+reader.dmLevel=winH25
+writer.dmLevel=fftcH25
+ ; for compatibility with 2.2.0 and older versions
+zeroPadSymmetric = 0
+
+[fftmp25:cFFTmagphase]
+reader.dmLevel=fftcH25
+writer.dmLevel=fftmagH25
+
+
+
+;;;;;;;;;;;;;;;;;;;; HPS pitch
+
+[componentInstances:cComponentManager]
+instance[scale].type=cSpecScale
+instance[shs].type=cPitchShs
+instance[pitchSmooth].type=cPitchSmoother
+instance[pitchSmooth2].type=cPitchSmoother
+
+
+[scale:cSpecScale]
+reader.dmLevel=fftmagG60
+writer.dmLevel=hpsG60
+copyInputName = 1
+processArrayFields = 0
+scale=octave
+sourceScale = lin
+// logScaleBase = 2
+// logSourceScaleBase = 2
+// firstNote = 55
+interpMethod = spline
+minF = 25
+maxF = -1
+nPointsTarget = 0
+specSmooth = 1
+specEnhance = 1
+auditoryWeighting = 1 
+
+[shs:cPitchShs]
+reader.dmLevel=hpsG60
+writer.dmLevel=pitchShsG60
+copyInputName = 1
+processArrayFields = 0
+maxPitch = 620
+minPitch = 52
+nCandidates = 4
+scores = 1
+voicing = 1
+F0C1 = 0
+voicingC1 = 0
+F0raw = 1
+voicingClip = 1
+voicingCutoff = 0.700000
+inputFieldSearch = Mag_octScale
+octaveCorrection = 0
+nHarmonics = 15
+compressionFactor = 0.850000
+
+[pitchSmooth:cPitchSmoother]
+reader.dmLevel=pitchShsG60
+writer.dmLevel=pitchG60
+copyInputName = 1
+processArrayFields = 0
+medianFilter0 = 0
+postSmoothing = 0
+postSmoothingMethod = simple
+ ; note: octave correction is too agressive, thus we disable it..
+octaveCorrection = 0
+F0final = 1
+F0finalEnv = 0
+no0f0 = 0
+voicingFinalClipped = 0
+voicingFinalUnclipped = 1
+F0raw = 0
+voicingC1 = 0
+voicingClip = 0
+
+[pitchSmooth2:cPitchSmoother]
+reader.dmLevel=pitchShsG60
+writer.dmLevel=pitchF
+F0raw = 0
+F0final = 1
+F0finalEnv = 0
+voicingFinalUnclipped = 0
+medianFilter0 = 0
+postSmoothingMethod = simple
+octaveCorrection = 0
+
+
+;;;;;;;;;;;;;;;;;;; VQ
+
+[componentInstances:cComponentManager]
+;instance[acf].type=cAcf
+;instance[hnr].type=cHnr
+instance[pitchJitter].type=cPitchJitter
+
+
+;[acf:cAcf]
+;reader.dmLevel=fftmagG60
+;writer.dmLevel=acfG60
+
+
+;[hnr:cHnr]
+;reader.dmLevel=pitchShsG60;acfG60
+;writer.dmLevel=hnr
+;hnrAvg = 1
+;hnr1 = 1
+;hnr2 
+;hnr3
+;hnr4
+;hnr5
+
+[pitchJitter:cPitchJitter]
+reader.dmLevel = wave
+writer.dmLevel = jitterShimmer
+// nameAppend =
+copyInputName = 1
+; is pitchF really necessary, or can we use pitchG60 ?
+F0reader.dmLevel = pitchF
+F0field = F0final
+searchRangeRel = 0.250000
+jitterLocal = 1
+jitterDDP = 1
+jitterLocalEnv = 0
+jitterDDPEnv = 0
+shimmerLocal = 1
+shimmerLocalEnv = 0
+onlyVoiced = 0
+logHNR = 1
+;periodLengths = 0
+;periodStarts = 0
+useBrokenJitterThresh = 1
+
+;;;;;;;;;;;;;;;;;;;;; Energy / loudness
+
+
+[componentInstances:cComponentManager]
+instance[energy].type=cEnergy
+instance[melspec1].type=cMelspec
+instance[audspec].type=cPlp
+instance[audspecRasta].type=cPlp
+instance[audspecSum].type=cVectorOperation
+instance[audspecRastaSum].type=cVectorOperation
+
+
+[energy:cEnergy]
+reader.dmLevel = frame25
+writer.dmLevel = energy
+log=0
+rms=1
+
+
+[melspec1:cMelspec]
+reader.dmLevel=fftmagH25
+writer.dmLevel=melspec1
+; htk compatible sample value scaling
+htkcompatible = 0
+nBands = 26
+; use power spectrum instead of magnitude spectrum
+usePower = 1
+lofreq = 20
+hifreq = 8000
+specScale = mel
+
+; perform auditory weighting of spectrum
+[audspec:cPlp]
+reader.dmLevel=melspec1
+writer.dmLevel=audspec
+firstCC = 0
+lpOrder = 5
+cepLifter = 22
+compression = 0.33
+htkcompatible = 0 
+doIDFT = 0
+doLpToCeps = 0
+doLP = 0
+doInvLog = 0
+doAud = 1
+doLog = 0
+newRASTA=0
+RASTA=0
+
+; perform RASTA style filtering of auditory spectra
+[audspecRasta:cPlp]
+reader.dmLevel=melspec1
+writer.dmLevel=audspecRasta
+nameAppend = Rfilt
+firstCC = 0
+lpOrder = 5
+cepLifter = 22
+compression = 0.33
+htkcompatible = 0 
+doIDFT = 0
+doLpToCeps = 0
+doLP = 0
+doInvLog = 0
+doAud = 1
+doLog = 0
+newRASTA=1
+RASTA=0
+
+[audspecSum:cVectorOperation]
+reader.dmLevel = audspec
+writer.dmLevel = audspecSum
+// nameAppend = 
+copyInputName = 1
+processArrayFields = 0
+operation = ll1
+nameBase = audspec
+
+[audspecRastaSum:cVectorOperation]
+reader.dmLevel = audspecRasta
+writer.dmLevel = audspecRastaSum
+// nameAppend = 
+copyInputName = 1
+processArrayFields = 0
+operation = ll1
+nameBase = audspecRasta
+
+;;;;;;;;;;;;;;; spectral
+
+[componentInstances:cComponentManager]
+instance[spectral].type=cSpectral
+
+
+[spectral:cSpectral]
+reader.dmLevel=fftmagH25
+writer.dmLevel=spectral
+bands[0]=250-650
+bands[1]=1000-4000
+rollOff[0] = 0.25
+rollOff[1] = 0.50
+rollOff[2] = 0.75
+rollOff[3] = 0.90
+flux=1
+centroid=0
+maxPos=0
+minPos=0
+entropy=1
+variance=1
+skewness=1
+kurtosis=1
+slope=1
+harmonicity=1
+sharpness=1
+
+
+;;;;;;;;;;;;;;; mfcc
+
+[componentInstances:cComponentManager]
+instance[melspecMfcc].type=cMelspec
+instance[mfcc].type=cMfcc
+
+[melspecMfcc:cMelspec]
+reader.dmLevel=fftmagH25
+writer.dmLevel=melspecMfcc
+copyInputName = 1
+processArrayFields = 1
+; htk compatible sample value scaling
+htkcompatible = 1
+nBands = 26s
+; use power spectrum instead of magnitude spectrum
+usePower = 1
+lofreq = 20
+hifreq = 8000
+specScale = mel
+inverse = 0
+
+[mfcc:cMfcc]
+reader.dmLevel=melspecMfcc
+writer.dmLevel=mfcc1_12
+copyInputName = 1
+processArrayFields = 1
+firstMfcc = 1
+lastMfcc  = 14
+cepLifter = 22.0
+htkcompatible = 1
+
+
+;;;;;;;;;;;;;;;;  zcr
+
+[componentInstances:cComponentManager]
+instance[mzcr].type=cMZcr
+
+[mzcr:cMZcr]
+reader.dmLevel = frame25
+writer.dmLevel = zcr
+copyInputName = 1
+processArrayFields = 1
+zcr = 1
+mcr = 0
+amax = 0
+maxmin = 0
+dc = 0
+
+
+;;;;;;;;;;;;;;;;; rasta-plp ?
+
+;;;;;;;;;;;;;;;;;;;; smoothing
+
+[componentInstances:cComponentManager]
+instance[smoNz].type=cContourSmoother
+instance[smoA].type=cContourSmoother
+instance[smoB].type=cContourSmoother
+instance[f0sel].type=cDataSelector
+
+[smoNz:cContourSmoother]
+reader.dmLevel = pitchG60;jitterShimmer
+writer.dmLevel = lld_nzsmo
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+nameAppend = sma
+copyInputName = 1
+noPostEOIprocessing = 0
+smaWin = 3
+noZeroSma = 1
+
+[f0sel:cDataSelector]
+reader.dmLevel = lld_nzsmo
+writer.dmLevel = lld_f0_nzsmo
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+nameAppend = ff0
+selected = F0final_sma
+
+[smoA:cContourSmoother]
+reader.dmLevel = audspecSum;audspecRastaSum;energy;zcr
+writer.dmLevel = lldA_smo
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+nameAppend = sma
+copyInputName = 1
+noPostEOIprocessing = 0
+smaWin = 3
+
+[smoB:cContourSmoother]
+reader.dmLevel = audspecRasta;spectral;mfcc1_12
+writer.dmLevel = lldB_smo
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+nameAppend = sma
+copyInputName = 1
+noPostEOIprocessing = 0
+smaWin = 3
+
+;;;;;;;;; deltas
+[componentInstances:cComponentManager]
+instance[deNz].type=cDeltaRegression
+instance[deA].type=cDeltaRegression
+instance[deB].type=cDeltaRegression
+instance[def0sel].type=cDeltaRegression
+
+[deNz:cDeltaRegression]
+reader.dmLevel = lld_nzsmo
+writer.dmLevel = lld_nzsmo_de
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+
+[deA:cDeltaRegression]
+reader.dmLevel = lldA_smo
+writer.dmLevel = lldA_smo_de
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+
+[deB:cDeltaRegression]
+reader.dmLevel = lldB_smo
+writer.dmLevel = lldB_smo_de
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+
+[def0sel:cDeltaRegression]
+reader.dmLevel = lld_f0_nzsmo
+writer.dmLevel = lld_f0_nzsmo_de
+writer.levelconf.isRb=0
+writer.levelconf.growDyn=1
+
+;;;;;;;;; functionals / statistics
+
+
+[componentInstances:cComponentManager]
+instance[functionalsA].type=cFunctionals
+instance[functionalsB].type=cFunctionals
+instance[functionalsF0].type=cFunctionals
+instance[functionalsNz].type=cFunctionals
+
+; shared functionals for LLD
+instance[functionalsLLD].type=cFunctionals
+
+; shared functionals for Delta LLD
+instance[functionalsDelta].type=cFunctionals
+
+
+; functionals for energy related lld
+[functionalsA:cFunctionals]
+reader.dmLevel = lldA_smo;lldA_smo_de
+writer.dmLevel = functionalsA
+// nameAppend = 
+copyInputName = 1
+frameMode = full
+frameSize = 0
+frameStep = 0
+frameCenterSpecial = left
+
+functionalsEnabled = Extremes ; Percentiles ; Moments ; Segments ; Times ;  Lpc
+
+Extremes.max = 0
+Extremes.min = 0
+Extremes.maxpos = 1
+Extremes.minpos = 1
+Extremes.maxameandist = 0
+Extremes.minameandist = 0
+
+Segments.maxNumSeg = 100
+Segments.segmentationAlgorithm = relTh
+Segments.thresholds = 0.25
+Segments.numSegments = 0
+Segments.meanSegLen = 1
+Segments.maxSegLen = 1
+Segments.minSegLen = 1
+Segments.segLenStddev = 1
+Segments.norm = second
+
+Moments.doRatioLimit = 0
+Moments.variance = 0
+Moments.stddev = 1
+Moments.skewness = 1
+Moments.kurtosis = 1
+Moments.amean = 0
+
+Percentiles.quartiles = 1
+Percentiles.iqr = 1
+Percentiles.percentile[0] = 0.01
+Percentiles.percentile[1] = 0.99
+Percentiles.pctlrange[0] = 0-1
+Percentiles.interp = 1
+
+Times.upleveltime25 = 1
+Times.downleveltime25 = 1
+Times.upleveltime50 = 1
+Times.downleveltime50 = 1
+Times.upleveltime75 = 1
+Times.downleveltime75 = 1
+Times.upleveltime90 = 1
+Times.downleveltime90 = 1
+Times.risetime = 1
+Times.falltime = 1
+Times.leftctime = 0
+Times.rightctime = 0
+Times.duration = 0
+Times.buggySecNorm = 0
+Times.norm = segment
+
+Lpc.lpGain = 1
+Lpc.lpc = 1
+Lpc.firstCoeff = 0
+Lpc.order = 5
+
+nonZeroFuncts = 0
+masterTimeNorm = segment
+
+
+
+; functionals for spectrum related lld
+[functionalsB:cFunctionals]
+reader.dmLevel = lldB_smo;lldB_smo_de
+writer.dmLevel = functionalsB
+// nameAppend = 
+copyInputName = 1
+frameMode = full
+frameSize = 0
+frameStep = 0
+frameCenterSpecial = left
+
+functionalsEnabled = Extremes ; Percentiles ; Moments ; Segments ; Times ;  Lpc
+
+Extremes.max = 0
+Extremes.min = 0
+Extremes.maxpos = 1
+Extremes.minpos = 1
+Extremes.maxameandist = 0
+Extremes.minameandist = 0
+
+Segments.maxNumSeg = 100
+Segments.segmentationAlgorithm = relTh
+Segments.thresholds = 0.25 ; 0.75
+Segments.rangeRelThreshold = 0.200000
+Segments.numSegments = 0
+Segments.meanSegLen = 1
+Segments.maxSegLen = 1
+Segments.minSegLen = 1
+Segments.segLenStddev = 1
+Segments.norm = second
+
+Moments.doRatioLimit = 0
+Moments.variance = 0
+Moments.stddev = 1
+Moments.skewness = 1
+Moments.kurtosis = 1
+Moments.amean = 0
+
+Percentiles.quartiles = 1
+Percentiles.iqr = 1
+Percentiles.percentile[0] = 0.01
+Percentiles.percentile[1] = 0.99
+Percentiles.pctlrange[0] = 0-1
+Percentiles.interp = 1
+
+Times.upleveltime25 = 1
+Times.downleveltime25 = 1
+Times.upleveltime50 = 1
+Times.downleveltime50 = 1
+Times.upleveltime75 = 1
+Times.downleveltime75 = 1
+Times.upleveltime90 = 1
+Times.downleveltime90 = 1
+Times.risetime = 1
+Times.falltime = 1
+Times.leftctime = 0
+Times.rightctime = 0
+Times.duration = 0
+Times.buggySecNorm = 0
+Times.norm = segment
+
+Lpc.lpGain = 1
+Lpc.lpc = 1
+Lpc.firstCoeff = 0
+Lpc.order = 5
+
+nonZeroFuncts = 0
+masterTimeNorm = segment
+
+
+
+; functionals for pitch onsets/offsets
+[functionalsF0:cFunctionals]
+reader.dmLevel = lld_f0_nzsmo
+writer.dmLevel = functionalsF0
+//nameAppend = ff0
+copyInputName = 1
+frameMode = full
+frameSize = 0
+frameStep = 0
+frameCenterSpecial = left
+
+functionalsEnabled = Means ; Segments ; Times
+
+Means.amean = 0
+Means.absmean = 0
+Means.qmean = 0
+Means.nzamean = 0
+Means.nzabsmean = 0
+Means.nzqmean = 0
+Means.nzgmean = 0
+Means.nnz = 1
+Means.norm = segment
+
+Segments.maxNumSeg = 100
+Segments.segmentationAlgorithm = nonX
+Segments.X = 0.0
+Segments.numSegments = 0
+Segments.meanSegLen = 1
+Segments.maxSegLen = 1
+Segments.minSegLen = 1
+Segments.segLenStddev = 1
+Segments.norm = second
+
+Times.upleveltime25 = 0
+Times.downleveltime25 = 0
+Times.upleveltime50 = 0
+Times.downleveltime50 = 0
+Times.upleveltime75 = 0
+Times.downleveltime75 = 0
+Times.upleveltime90 = 0
+Times.downleveltime90 = 0
+Times.risetime = 0
+Times.falltime = 0
+Times.leftctime = 0
+Times.rightctime = 0
+Times.duration = 0
+Times.buggySecNorm = 0
+Times.norm = second
+
+nonZeroFuncts = 0
+masterTimeNorm = segment
+
+
+
+; functionals for pitch and vq related lld in voiced regions
+[functionalsNz:cFunctionals]
+reader.dmLevel = lld_nzsmo;lld_nzsmo_de
+writer.dmLevel = functionalsNz
+// nameAppend = 
+copyInputName = 1
+frameMode = full
+frameSize = 0
+frameStep = 0
+frameCenterSpecial = left
+
+functionalsEnabled = Extremes ; Percentiles ; Moments ; Times ; Lpc
+
+
+Extremes.max = 0
+Extremes.min = 0
+Extremes.maxpos = 1
+Extremes.minpos = 1
+Extremes.maxameandist = 0
+Extremes.minameandist = 0
+
+Moments.doRatioLimit = 0
+Moments.variance = 0
+Moments.stddev = 1
+Moments.skewness = 1
+Moments.kurtosis = 1
+Moments.amean = 0
+
+Percentiles.quartiles = 1
+Percentiles.iqr = 1
+Percentiles.percentile[0] = 0.01
+Percentiles.percentile[1] = 0.99
+Percentiles.pctlrange[0] = 0-1
+Percentiles.interp = 1
+
+Times.upleveltime25 = 1
+Times.downleveltime25 = 1
+Times.upleveltime50 = 1
+Times.downleveltime50 = 1
+Times.upleveltime75 = 1
+Times.downleveltime75 = 1
+Times.upleveltime90 = 1
+Times.downleveltime90 = 1
+Times.risetime = 1
+Times.falltime = 1
+Times.leftctime = 1
+Times.rightctime = 1
+Times.duration = 0
+Times.buggySecNorm = 0
+Times.norm = segment
+
+Lpc.lpGain = 1
+Lpc.lpc = 1
+Lpc.firstCoeff = 0
+Lpc.order = 5
+
+nonZeroFuncts = 1
+masterTimeNorm = segment
+
+
+
+[functionalsLLD:cFunctionals]
+reader.dmLevel = lldA_smo;lldB_smo;lld_nzsmo
+writer.dmLevel = functionalsLLD
+
+copyInputName = 1
+frameMode = full
+frameSize = 0
+frameStep = 0
+frameCenterSpecial = left
+
+functionalsEnabled = Means ; Peaks2 ; Regression
+
+Means.amean = 1
+Means.posamean = 0
+Means.absmean = 0
+Means.qmean = 0
+Means.rqmean = 1
+Means.nzamean = 0
+Means.nzabsmean = 0
+Means.nzqmean = 0
+Means.posrqmean = 0
+Means.nzgmean = 0
+Means.nnz = 0
+Means.flatness = 1
+Means.norm = frames
+
+Regression.centroidUseAbsValues = 0
+Regression.centroidRatioLimit = 0
+Regression.doRatioLimit = 0
+Regression.linregc1 = 1
+Regression.linregc2 = 1
+Regression.linregerrA = 0
+Regression.linregerrQ = 1
+Regression.qregc1 = 1
+Regression.qregc2 = 1
+Regression.qregc3 = 1
+Regression.qregerrA = 0
+Regression.qregerrQ = 1
+Regression.oldBuggyQerr = 0
+Regression.centroid = 1
+Regression.normRegCoeff = 0
+
+Peaks2.doRatioLimit = 0
+Peaks2.numPeaks = 0
+Peaks2.meanPeakDist = 1
+Peaks2.meanPeakDistDelta = 0
+Peaks2.peakDistStddev = 1
+Peaks2.peakRangeAbs = 1
+Peaks2.peakRangeRel = 1
+Peaks2.peakMeanAbs = 1
+Peaks2.peakMeanMeanDist = 1
+Peaks2.peakMeanRel = 1
+Peaks2.ptpAmpMeanAbs = 0
+Peaks2.ptpAmpMeanRel = 0
+Peaks2.ptpAmpStddevAbs = 0
+Peaks2.ptpAmpStddevRel = 0
+Peaks2.minRangeAbs = 0
+Peaks2.minRangeRel = 1
+Peaks2.minMeanAbs = 0
+Peaks2.minMeanMeanDist = 0
+Peaks2.minMeanRel = 0
+Peaks2.mtmAmpMeanAbs = 0
+Peaks2.mtmAmpMeanRel = 0
+Peaks2.mtmAmpStddevAbs = 0
+Peaks2.mtmAmpStddevRel = 0
+Peaks2.meanRisingSlope = 1
+Peaks2.maxRisingSlope = 0
+Peaks2.minRisingSlope = 0
+Peaks2.stddevRisingSlope = 1
+Peaks2.meanFallingSlope = 1
+Peaks2.maxFallingSlope = 0
+Peaks2.minFallingSlope = 0
+Peaks2.stddevFallingSlope = 1
+Peaks2.norm = seconds
+Peaks2.relThresh = 0.100000
+Peaks2.dynRelThresh = 0
+;Peaks2.posDbgOutp = minmax.txt
+Peaks2.posDbgAppend = 0
+Peaks2.consoleDbg = 0
+
+
+[functionalsDelta:cFunctionals]
+reader.dmLevel = lldA_smo_de;lldB_smo_de;lld_nzsmo_de
+writer.dmLevel = functionalsDelta
+
+copyInputName = 1
+frameMode = full
+frameSize = 0
+frameStep = 0
+frameCenterSpecial = left
+
+functionalsEnabled = Means
+
+Means.amean = 0
+Means.posamean = 1
+Means.absmean = 0
+Means.qmean = 0
+Means.rqmean = 1
+Means.nzamean = 0
+Means.nzabsmean = 0
+Means.nzqmean = 0
+Means.posrqmean = 0
+Means.nzgmean = 0
+Means.nnz = 0
+Means.flatness = 1
+Means.norm = frames
+
+;;;;;;;;; prepare features for standard output module
+
+[componentInstances:cComponentManager]
+instance[lldconcat].type=cVectorConcat
+instance[llddeconcat].type=cVectorConcat
+instance[funcconcat].type=cVectorConcat
+
+[lldconcat:cVectorConcat]
+reader.dmLevel = lld_nzsmo;lldA_smo;lldB_smo
+writer.dmLevel = lld
+includeSingleElementFields = 1
+
+[llddeconcat:cVectorConcat]
+reader.dmLevel = lld_nzsmo_de;lldA_smo_de;lldB_smo_de
+writer.dmLevel = lld_de
+includeSingleElementFields = 1
+
+[funcconcat:cVectorConcat]
+reader.dmLevel = functionalsA;functionalsB;functionalsNz;functionalsF0;functionalsLLD;functionalsDelta
+writer.dmLevel = func
+includeSingleElementFields = 1
+
+
+\{\cm[sink{?}:include external sink]}

--- a/opensmile/core/config/is09-13/IS13_ComParE.conf
+++ b/opensmile/core/config/is09-13/IS13_ComParE.conf
@@ -1,0 +1,46 @@
+///////////////////////////////////////////////////////////////////////////////////////
+///////// > openSMILE configuration file for ComParE <               //////////////////
+/////////                                                            //////////////////
+///////// (c) 2014 by audEERING                                      //////////////////
+/////////     All rights reserved. See file COPYING for details.     //////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+
+
+
+;;;;;;; component list ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+[componentInstances:cComponentManager]
+instance[dataMemory].type=cDataMemory
+printLevelStats=0
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;; main section ;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+\{\cm[source{?}:include external source]}
+\{IS13_ComParE_core.lld.conf.inc}
+\{IS13_ComParE_core.func.conf.inc}
+
+;;;;;;;;; prepare features for standard output module
+
+[componentInstances:cComponentManager]
+instance[is13_lldconcat].type=cVectorConcat
+instance[is13_llddeconcat].type=cVectorConcat
+instance[is13_funcconcat].type=cVectorConcat
+
+[is13_lldconcat:cVectorConcat]
+reader.dmLevel = is13_lld_nzsmo;is13_lldA_smo;is13_lldB_smo
+writer.dmLevel = lld
+includeSingleElementFields = 1
+
+[is13_llddeconcat:cVectorConcat]
+reader.dmLevel = is13_lld_nzsmo_de;is13_lldA_smo_de;is13_lldB_smo_de
+writer.dmLevel = lld_de
+includeSingleElementFields = 1
+
+[is13_funcconcat:cVectorConcat]
+reader.dmLevel = is13_functionalsA;is13_functionalsB;is13_functionalsNz;is13_functionalsF0;is13_functionalsLLD;is13_functionalsDelta
+writer.dmLevel = func
+includeSingleElementFields = 1
+
+\{\cm[sink{?}:include external sink]}
+

--- a/opensmile/core/config/is09-13/IS13_ComParE_Voc.conf
+++ b/opensmile/core/config/is09-13/IS13_ComParE_Voc.conf
@@ -1,0 +1,237 @@
+///////////////////////////////////////////////////////////////////////////////////////
+///////// > openSMILE configuration file for ComParE vocalistions <  //////////////////
+/////////                                                            //////////////////
+///////// (c) 2014 by audEERING                                      //////////////////
+/////////     All rights reserved. See file COPYING for details.     //////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+
+
+
+[componentInstances:cComponentManager]
+instance[dataMemory].type=cDataMemory
+instance[waveIn].type=cWaveSource
+instance[fr1].type=cFramer
+instance[pe2].type=cVectorPreemphasis
+instance[w1].type=cWindower
+instance[fft1].type=cTransformFFT
+instance[fftmp1].type=cFFTmagphase
+instance[acf].type=cAcf
+instance[cepstrum].type=cAcf
+instance[pitchACF].type=cPitchACF
+instance[mspec].type=cMelspec
+instance[mfcc].type=cMfcc
+instance[energy].type=cEnergy
+instance[mzcr].type=cMZcr
+instance[cms].type=cFullinputMean
+instance[cmsD].type=cFullinputMean
+instance[cmsA].type=cFullinputMean
+instance[vc1].type=cVectorConcat
+instance[delta1].type=cDeltaRegression
+instance[delta2].type=cDeltaRegression
+instance[delta1e].type=cDeltaRegression
+instance[delta2e].type=cDeltaRegression
+instance[deltapitch].type=cDeltaRegression
+instance[deltazcr].type=cDeltaRegression
+instance[framestacking].type=cFunctionals
+instance[arffout].type=cArffSink
+nThreads=1
+printLevelStats=0
+
+[waveIn:cWaveSource]
+writer.dmLevel=wave
+filename=\cm[inputfile(I){test.wav}:name of input file]
+;buffersize=16000
+monoMixdown=1
+
+[fr1:cFramer]
+reader.dmLevel=wave
+writer.dmLevel=outp
+frameSize = 0.0250
+frameStep = 0.010
+frameCenterSpecial = left
+
+[pe2:cVectorPreemphasis]
+reader.dmLevel=outp
+writer.dmLevel=output
+k=0.97
+
+
+[w1:cWindower]
+reader.dmLevel=output
+writer.dmLevel=winoutput
+winFunc = ham
+gain = 1.0
+
+[fft1:cTransformFFT]
+reader.dmLevel=winoutput
+writer.dmLevel=fftc1
+
+[fftmp1:cFFTmagphase]
+reader.dmLevel=fftc1
+writer.dmLevel=fft1
+
+[acf:cAcf]
+reader.dmLevel=fft1
+writer.dmLevel=acf
+nameAppend = acf
+copyInputName = 1
+processArrayFields = 1
+usePower = 1
+cepstrum = 0
+
+[cepstrum:cAcf]
+reader.dmLevel=fft1
+writer.dmLevel=cepstrum
+nameAppend = acf
+copyInputName = 1
+processArrayFields = 1
+usePower = 1
+cepstrum = 1
+
+[pitchACF:cPitchACF]
+  ; the pitchACF component must ALWAYS read from acf AND cepstrum in the given order!
+reader.dmLevel=acf;cepstrum
+writer.dmLevel=pitch
+writer.levelconf.growDyn=1
+writer.levelconf.isRb=0
+copyInputName = 1
+processArrayFields = 0
+maxPitch = 500
+voiceProb = 1
+voiceQual = 0
+HNR = 1
+F0 = 1
+F0raw = 0
+F0env = 0
+voicingCutoff = 0.550000
+
+[mspec:cMelspec]
+reader.dmLevel=fft1
+writer.dmLevel=mspec1
+htkcompatible = 1
+nBands = 26
+usePower = 1
+lofreq = 0
+hifreq = 8000
+
+[mfcc:cMfcc]
+reader.dmLevel=mspec1
+writer.dmLevel=mfcc1
+writer.levelconf.growDyn=1
+writer.levelconf.isRb=0
+buffersize=1000
+firstMfcc = 1
+lastMfcc =  12
+htkcompatible = 1
+
+[cms:cFullinputMean]
+reader.dmLevel=mfcc1
+writer.dmLevel=mfcc1m
+multiLoopMode=1
+
+[cmsD:cFullinputMean]
+reader.dmLevel=mfcc1de
+writer.dmLevel=mfcc1dem
+multiLoopMode=1
+
+[cmsA:cFullinputMean]
+reader.dmLevel=mfcc1dede
+writer.dmLevel=mfcc1dedem
+multiLoopMode=1
+
+
+[vc1:cVectorConcat]
+reader.dmLevel=mfcc1m;energy;mfcc1dem;energyDe;mfcc1dedem;energyDede
+writer.dmLevel=ft0
+processArrayFields=0
+
+[delta1:cDeltaRegression]
+reader.dmLevel=mfcc1
+writer.dmLevel=mfcc1de
+deltawin=2
+blocksize=1
+
+[delta2:cDeltaRegression]
+reader.dmLevel=mfcc1de
+writer.dmLevel=mfcc1dede
+deltawin=2
+blocksize=1
+
+[delta1e:cDeltaRegression]
+reader.dmLevel=energy
+writer.dmLevel=energyDe
+deltawin=2
+blocksize=1
+
+[delta2e:cDeltaRegression]
+reader.dmLevel=energyDe
+writer.dmLevel=energyDede
+deltawin=2
+blocksize=1
+
+[deltapitch:cDeltaRegression]
+reader.dmLevel=pitch
+writer.dmLevel=pitchde
+deltawin=2
+blocksize=1
+onlyInSegments=1
+zeroSegBound=1
+
+[deltazcr:cDeltaRegression]
+reader.dmLevel=zcr
+writer.dmLevel=zcrde
+deltawin=2
+blocksize=1
+
+[energy:cEnergy]
+reader.dmLevel=outp
+writer.dmLevel=energy
+writer.levelconf.growDyn=1
+writer.levelconf.isRb=0
+buffersize=1000
+htkcompatible=1
+
+[mzcr:cMZcr]
+reader.dmLevel=outp
+writer.dmLevel=zcr
+writer.levelconf.growDyn=1
+writer.levelconf.isRb=0
+copyInputName = 1
+processArrayFields = 1
+zcr = 1
+amax = 0
+mcr = 0
+maxmin = 0
+dc = 0
+
+[framestacking:cFunctionals]
+reader.dmLevel = mfcc1m;energy;mfcc1dem;energyDe;mfcc1dedem;energyDede;pitch;pitchde;zcr;zcrde
+;ft0
+writer.dmLevel = fts
+;frameCenterSpecial = mid
+frameCenterFrames = \cm[stackC{2}:frame center]
+frameSizeFrames = \cm[stack(S){5}:number of frames to stack]
+frameStepFrames = 1
+functionalsEnabled = Moments
+Moments.variance = 0
+Moments.stddev = 1
+Moments.skewness = 0
+Moments.kurtosis = 0
+Moments.amean = 1
+noPostEOIprocessing = 0
+
+[arffout:cArffSink]
+relation = COMPARE2013_Vocalisations
+;instanceBase=\cm[instName{file}:instance name]
+instanceName=\cm[instName{file}:instance name]
+reader.dmLevel=mfcc1m;energy;mfcc1dem;energyDe;mfcc1dedem;energyDede;pitch;pitchde;zcr;zcrde;fts
+;reader.dmLevel=fts
+filename=\cm[output(O){mfcc.arff}:name of MFCC output filename (ARFF format)]
+frameIndex = 1
+frameTime = 0
+append = 1
+class[0].type = { garbage, laughter, filler }
+; default class
+target[0].all = garbage
+target[0].instance = \cm[frameClasses(T){garbage}:list of class labels for frames]
+

--- a/opensmile/core/config/is09-13/IS13_ComParE_core.func.conf.inc
+++ b/opensmile/core/config/is09-13/IS13_ComParE_core.func.conf.inc
@@ -1,0 +1,382 @@
+///////////////////////////////////////////////////////////////////////////////////////
+///////// > openSMILE configuration file for ComParE <               //////////////////
+/////////                                                            //////////////////
+///////// (c) 2014 by audEERING                                      //////////////////
+/////////     All rights reserved. See file COPYING for details.     //////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+
+
+;;;;;;;;; functionals / statistics
+
+
+[componentInstances:cComponentManager]
+instance[is13_functionalsA].type=cFunctionals
+instance[is13_functionalsB].type=cFunctionals
+instance[is13_functionalsF0].type=cFunctionals
+instance[is13_functionalsNz].type=cFunctionals
+; shared functionals for LLD
+instance[is13_functionalsLLD].type=cFunctionals
+; shared functionals for Delta LLD
+instance[is13_functionalsDelta].type=cFunctionals
+
+
+; functionals for energy related lld
+[is13_functionalsA:cFunctionals]
+reader.dmLevel = is13_lldA_smo;is13_lldA_smo_de
+writer.dmLevel = is13_functionalsA
+// nameAppend = 
+copyInputName = 1
+\{\cm[bufferModeRbConf]}
+\{\cm[frameModeFunctionalsConf{../shared/FrameModeFunctionals.conf.inc}:path to included config to set frame mode for all functionals]}
+functionalsEnabled = Extremes ; Percentiles ; Moments ; Segments ; Times ;  Lpc
+Extremes.max = 0
+Extremes.min = 0
+Extremes.maxpos = 1
+Extremes.minpos = 1
+Extremes.maxameandist = 0
+Extremes.minameandist = 0
+Segments.maxNumSeg = 100
+Segments.segmentationAlgorithm = relTh
+Segments.thresholds = 0.25 ; 0.75
+Segments.ravgLng = 3
+Segments.numSegments = 0
+Segments.meanSegLen = 1
+Segments.maxSegLen = 1
+Segments.minSegLen = 1
+Segments.segLenStddev = 1
+Segments.norm = second
+Moments.doRatioLimit = 0
+Moments.variance = 0
+Moments.stddev = 1
+Moments.skewness = 1
+Moments.kurtosis = 1
+Moments.amean = 0
+Percentiles.quartiles = 1
+Percentiles.iqr = 1
+Percentiles.percentile[0] = 0.01
+Percentiles.percentile[1] = 0.99
+Percentiles.pctlrange[0] = 0-1
+Percentiles.interp = 1
+Times.upleveltime25 = 1
+Times.downleveltime25 = 0
+Times.upleveltime50 = 1
+Times.downleveltime50 = 0
+Times.upleveltime75 = 1
+Times.downleveltime75 = 0
+Times.upleveltime90 = 1
+Times.downleveltime90 = 0
+Times.risetime = 1
+Times.falltime = 0
+Times.leftctime = 1
+Times.rightctime = 0
+Times.duration = 0
+Times.buggySecNorm = 0
+Times.norm = segment
+Lpc.lpGain = 1
+Lpc.lpc = 1
+Lpc.firstCoeff = 0
+Lpc.order = 5
+nonZeroFuncts = 0
+masterTimeNorm = segment
+
+; functionals for spectrum related lld
+[is13_functionalsB:cFunctionals]
+reader.dmLevel = is13_lldB_smo;is13_lldB_smo_de
+writer.dmLevel = is13_functionalsB
+// nameAppend = 
+copyInputName = 1
+\{\cm[bufferModeRbConf]}
+\{\cm[frameModeFunctionalsConf]}
+functionalsEnabled = Extremes ; Percentiles ; Moments ; Segments ; Times ;  Lpc
+Extremes.max = 0
+Extremes.min = 0
+Extremes.maxpos = 1
+Extremes.minpos = 1
+Extremes.maxameandist = 0
+Extremes.minameandist = 0
+Segments.maxNumSeg = 100
+Segments.segmentationAlgorithm = relTh
+Segments.thresholds = 0.25 ; 0.75
+Segments.rangeRelThreshold = 0.200000
+Segments.numSegments = 0
+Segments.meanSegLen = 1
+Segments.maxSegLen = 1
+Segments.minSegLen = 1
+Segments.segLenStddev = 1
+Segments.norm = second
+Moments.doRatioLimit = 0
+Moments.variance = 0
+Moments.stddev = 1
+Moments.skewness = 1
+Moments.kurtosis = 1
+Moments.amean = 0
+Percentiles.quartiles = 1
+Percentiles.iqr = 1
+Percentiles.percentile[0] = 0.01
+Percentiles.percentile[1] = 0.99
+Percentiles.pctlrange[0] = 0-1
+Percentiles.interp = 1
+Times.upleveltime25 = 1
+Times.downleveltime25 = 0
+Times.upleveltime50 = 1
+Times.downleveltime50 = 0
+Times.upleveltime75 = 1
+Times.downleveltime75 = 0
+Times.upleveltime90 = 1
+Times.downleveltime90 = 0
+Times.risetime = 1
+Times.falltime = 0
+Times.leftctime = 1
+Times.rightctime = 0
+Times.duration = 0
+Times.buggySecNorm = 0
+Times.norm = segment
+Lpc.lpGain = 1
+Lpc.lpc = 1
+Lpc.firstCoeff = 0
+Lpc.order = 5
+nonZeroFuncts = 0
+masterTimeNorm = segment
+
+; functionals for pitch onsets/offsets
+[is13_functionalsF0:cFunctionals]
+reader.dmLevel = is13_lld_f0_nzsmo
+writer.dmLevel = is13_functionalsF0
+//nameAppend = ff0
+copyInputName = 1
+\{\cm[bufferModeRbConf]}
+\{\cm[frameModeFunctionalsConf]}
+functionalsEnabled = Means ; Segments 
+Means.amean = 0
+Means.absmean = 0
+Means.qmean = 0
+Means.nzamean = 0
+Means.nzabsmean = 0
+Means.nzqmean = 0
+Means.nzgmean = 0
+Means.nnz = 1
+Means.norm = segment
+Segments.maxNumSeg = 100
+Segments.segmentationAlgorithm = nonX
+Segments.X = 0.0
+Segments.numSegments = 0
+Segments.meanSegLen = 1
+Segments.maxSegLen = 1
+Segments.minSegLen = 1
+Segments.segLenStddev = 1
+Segments.norm = second
+nonZeroFuncts = 0
+masterTimeNorm = segment
+
+; functionals for pitch and vq related lld in voiced regions
+[is13_functionalsNz:cFunctionals]
+reader.dmLevel = is13_lld_nzsmo;is13_lld_nzsmo_de
+writer.dmLevel = is13_functionalsNz
+// nameAppend = 
+copyInputName = 1
+\{\cm[bufferModeRbConf]}
+\{\cm[frameModeFunctionalsConf]}
+functionalsEnabled = Means ; Extremes ; Regression ; Percentiles ; Moments ; Times ; Lpc
+Means.amean = 1
+Means.posamean = 1
+Means.absmean = 0
+Means.qmean = 0
+Means.rqmean = 1
+Means.nzamean = 0
+Means.nzabsmean = 0
+Means.nzqmean = 0
+Means.posrqmean = 0
+Means.nzgmean = 0
+Means.nnz = 0
+Means.flatness = 1
+Means.norm = frames
+Extremes.max = 0
+Extremes.min = 0
+Extremes.maxpos = 1
+Extremes.minpos = 1
+Extremes.maxameandist = 0
+Extremes.minameandist = 0
+Moments.doRatioLimit = 0
+Moments.variance = 0
+Moments.stddev = 1
+Moments.skewness = 1
+Moments.kurtosis = 1
+Moments.amean = 0
+Regression.centroidUseAbsValues = 0
+Regression.centroidRatioLimit = 0
+Regression.doRatioLimit = 0
+Regression.linregc1 = 1
+Regression.linregc2 = 1
+Regression.linregerrA = 0
+Regression.linregerrQ = 1
+Regression.qregc1 = 1
+Regression.qregc2 = 1
+Regression.qregc3 = 1
+Regression.qregerrA = 0
+Regression.qregerrQ = 1
+Regression.oldBuggyQerr = 0
+Regression.centroid = 1
+Regression.normRegCoeff = 0
+Percentiles.quartiles = 1
+Percentiles.iqr = 1
+Percentiles.percentile[0] = 0.01
+Percentiles.percentile[1] = 0.99
+Percentiles.pctlrange[0] = 0-1
+Percentiles.interp = 1
+Times.upleveltime25 = 1
+Times.downleveltime25 = 0
+Times.upleveltime50 = 1
+Times.downleveltime50 = 0
+Times.upleveltime75 = 1
+Times.downleveltime75 = 0
+Times.upleveltime90 = 1
+Times.downleveltime90 = 0
+Times.risetime = 1
+Times.falltime = 0
+Times.leftctime = 1
+Times.rightctime = 0
+Times.duration = 0
+Times.buggySecNorm = 0
+Times.norm = segment
+Lpc.lpGain = 1
+Lpc.lpc = 1
+Lpc.firstCoeff = 0
+Lpc.order = 5
+nonZeroFuncts = 1
+masterTimeNorm = segment
+
+
+[is13_functionalsLLD:cFunctionals]
+reader.dmLevel = is13_lldA_smo;is13_lldB_smo
+writer.dmLevel = is13_functionalsLLD
+copyInputName = 1
+\{\cm[bufferModeRbConf]}
+\{\cm[frameModeFunctionalsConf]}
+functionalsEnabled = Means ; Peaks2 ; Regression
+Means.amean = 1
+Means.posamean = 0
+Means.absmean = 0
+Means.qmean = 0
+Means.rqmean = 1
+Means.nzamean = 0
+Means.nzabsmean = 0
+Means.nzqmean = 0
+Means.posrqmean = 0
+Means.nzgmean = 0
+Means.nnz = 0
+Means.flatness = 1
+Means.norm = frames
+Regression.centroidUseAbsValues = 0
+Regression.centroidRatioLimit = 0
+Regression.doRatioLimit = 0
+Regression.linregc1 = 1
+Regression.linregc2 = 1
+Regression.linregerrA = 0
+Regression.linregerrQ = 1
+Regression.qregc1 = 1
+Regression.qregc2 = 1
+Regression.qregc3 = 1
+Regression.qregerrA = 0
+Regression.qregerrQ = 1
+Regression.oldBuggyQerr = 0
+Regression.centroid = 1
+Regression.normRegCoeff = 0
+Peaks2.doRatioLimit = 0
+Peaks2.numPeaks = 0
+Peaks2.meanPeakDist = 1
+Peaks2.meanPeakDistDelta = 0
+Peaks2.peakDistStddev = 1
+Peaks2.peakRangeAbs = 1
+Peaks2.peakRangeRel = 1
+Peaks2.peakMeanAbs = 1
+Peaks2.peakMeanMeanDist = 1
+Peaks2.peakMeanRel = 1
+Peaks2.ptpAmpMeanAbs = 0
+Peaks2.ptpAmpMeanRel = 0
+Peaks2.ptpAmpStddevAbs = 0
+Peaks2.ptpAmpStddevRel = 0
+Peaks2.minRangeAbs = 0
+Peaks2.minRangeRel = 1
+Peaks2.minMeanAbs = 0
+Peaks2.minMeanMeanDist = 0
+Peaks2.minMeanRel = 0
+Peaks2.mtmAmpMeanAbs = 0
+Peaks2.mtmAmpMeanRel = 0
+Peaks2.mtmAmpStddevAbs = 0
+Peaks2.mtmAmpStddevRel = 0
+Peaks2.meanRisingSlope = 1
+Peaks2.maxRisingSlope = 0
+Peaks2.minRisingSlope = 0
+Peaks2.stddevRisingSlope = 1
+Peaks2.meanFallingSlope = 1
+Peaks2.maxFallingSlope = 0
+Peaks2.minFallingSlope = 0
+Peaks2.stddevFallingSlope = 1
+Peaks2.norm = seconds
+Peaks2.relThresh = 0.100000
+Peaks2.dynRelThresh = 0
+;Peaks2.posDbgOutp = minmax.txt
+Peaks2.posDbgAppend = 0
+Peaks2.consoleDbg = 0
+
+
+[is13_functionalsDelta:cFunctionals]
+reader.dmLevel = is13_lldA_smo_de;is13_lldB_smo_de
+writer.dmLevel = is13_functionalsDelta
+copyInputName = 1
+\{\cm[bufferModeRbConf]}
+\{\cm[frameModeFunctionalsConf]}
+functionalsEnabled = Means ; Peaks2
+Means.amean = 0
+Means.posamean = 1
+Means.absmean = 0
+Means.qmean = 0
+Means.rqmean = 1
+Means.nzamean = 0
+Means.nzabsmean = 0
+Means.nzqmean = 0
+Means.posrqmean = 0
+Means.nzgmean = 0
+Means.nnz = 0
+Means.flatness = 1
+Means.norm = frames
+Peaks2.doRatioLimit = 0
+Peaks2.numPeaks = 0
+Peaks2.meanPeakDist = 1
+Peaks2.meanPeakDistDelta = 0
+Peaks2.peakDistStddev = 1
+Peaks2.peakRangeAbs = 1
+Peaks2.peakRangeRel = 1
+Peaks2.peakMeanAbs = 1
+Peaks2.peakMeanMeanDist = 1
+Peaks2.peakMeanRel = 1
+Peaks2.ptpAmpMeanAbs = 0
+Peaks2.ptpAmpMeanRel = 0
+Peaks2.ptpAmpStddevAbs = 0
+Peaks2.ptpAmpStddevRel = 0
+Peaks2.minRangeAbs = 0
+Peaks2.minRangeRel = 1
+Peaks2.minMeanAbs = 0
+Peaks2.minMeanMeanDist = 0
+Peaks2.minMeanRel = 0
+Peaks2.mtmAmpMeanAbs = 0
+Peaks2.mtmAmpMeanRel = 0
+Peaks2.mtmAmpStddevAbs = 0
+Peaks2.mtmAmpStddevRel = 0
+Peaks2.meanRisingSlope = 1
+Peaks2.maxRisingSlope = 0
+Peaks2.minRisingSlope = 0
+Peaks2.stddevRisingSlope = 1
+Peaks2.meanFallingSlope = 1
+Peaks2.maxFallingSlope = 0
+Peaks2.minFallingSlope = 0
+Peaks2.stddevFallingSlope = 1
+Peaks2.norm = seconds
+Peaks2.relThresh = 0.100000
+Peaks2.dynRelThresh = 0
+;Peaks2.posDbgOutp = minmax.txt
+Peaks2.posDbgAppend = 0
+Peaks2.consoleDbg = 0
+
+
+

--- a/opensmile/core/config/is09-13/IS13_ComParE_core.lld.conf.inc
+++ b/opensmile/core/config/is09-13/IS13_ComParE_core.lld.conf.inc
@@ -1,0 +1,432 @@
+///////////////////////////////////////////////////////////////////////////////////////
+///////// > openSMILE configuration file for ComParE <               //////////////////
+/////////                                                            //////////////////
+///////// (c) 2014 by audEERING                                      //////////////////
+/////////     All rights reserved. See file COPYING for details.     //////////////////
+///////////////////////////////////////////////////////////////////////////////////////
+
+
+
+[componentInstances:cComponentManager]
+instance[is13_frame60].type=cFramer
+instance[is13_win60].type=cWindower
+instance[is13_fft60].type=cTransformFFT
+instance[is13_fftmp60].type=cFFTmagphase
+
+[is13_frame60:cFramer]
+reader.dmLevel=wave
+writer.dmLevel=is13_frame60
+\{\cm[bufferModeRbConf{../shared/BufferModeRb.conf.inc}:path to included config to set the buffer mode for the standard ringbuffer levels]}
+frameSize = 0.060
+frameStep = 0.010
+frameCenterSpecial = left
+
+[is13_win60:cWindower]
+reader.dmLevel=is13_frame60
+writer.dmLevel=is13_winG60
+winFunc=gauss
+gain=1.0
+sigma=0.4
+
+[is13_fft60:cTransformFFT]
+reader.dmLevel=is13_winG60
+writer.dmLevel=is13_fftcG60
+ ; for compatibility with 2.2.0 and older versions
+zeroPadSymmetric = 0
+
+[is13_fftmp60:cFFTmagphase]
+reader.dmLevel=is13_fftcG60
+writer.dmLevel=is13_fftmagG60
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+[componentInstances:cComponentManager]
+instance[is13_frame25].type=cFramer
+instance[is13_win25].type=cWindower
+instance[is13_fft25].type=cTransformFFT
+instance[is13_fftmp25].type=cFFTmagphase
+
+[is13_frame25:cFramer]
+reader.dmLevel=wave
+writer.dmLevel=is13_frame25
+\{\cm[bufferModeRbConf]}
+frameSize = 0.020
+frameStep = 0.010
+frameCenterSpecial = left
+
+[is13_win25:cWindower]
+reader.dmLevel=is13_frame25
+writer.dmLevel=is13_winH25
+winFunc=hamming
+
+[is13_fft25:cTransformFFT]
+reader.dmLevel=is13_winH25
+writer.dmLevel=is13_fftcH25
+ ; for compatibility with 2.2.0 and older versions
+zeroPadSymmetric = 0
+
+[is13_fftmp25:cFFTmagphase]
+reader.dmLevel=is13_fftcH25
+writer.dmLevel=is13_fftmagH25
+
+
+
+;;;;;;;;;;;;;;;;;;;; HPS pitch
+
+[componentInstances:cComponentManager]
+instance[is13_scale].type=cSpecScale
+instance[is13_shs].type=cPitchShs
+
+[is13_scale:cSpecScale]
+reader.dmLevel=is13_fftmagG60
+writer.dmLevel=is13_hpsG60
+copyInputName = 1
+processArrayFields = 0
+scale=octave
+sourceScale = lin
+interpMethod = spline
+minF = 25
+maxF = -1
+nPointsTarget = 0
+specSmooth = 1
+specEnhance = 1
+auditoryWeighting = 1 
+
+[is13_shs:cPitchShs]
+reader.dmLevel=is13_hpsG60
+writer.dmLevel=is13_pitchShsG60
+\{\cm[bufferModeRbLagConf{../shared/BufferModeRbLag.conf.inc}:path to included config to set the buffer mode for levels which will be joint with Viterbi smoothed -lagged- F0]}
+copyInputName = 1
+processArrayFields = 0
+maxPitch = 620
+minPitch = 52
+nCandidates = 6
+scores = 1
+voicing = 1
+F0C1 = 0
+voicingC1 = 0
+F0raw = 1
+voicingClip = 1
+voicingCutoff = 0.700000
+inputFieldSearch = Mag_octScale
+octaveCorrection = 0
+nHarmonics = 15
+compressionFactor = 0.850000
+greedyPeakAlgo = 1
+
+;;;;; Pitch with Viterbi smoother
+[componentInstances:cComponentManager]
+instance[is13_energy60].type=cEnergy
+
+[is13_energy60:cEnergy]
+reader.dmLevel=is13_winG60
+writer.dmLevel=is13_e60
+ ; This must be > than buffersize of viterbi smoother
+\{\cm[bufferModeRbLagConf]}
+rms=1
+log=0
+
+[componentInstances:cComponentManager]
+instance[is13_pitchSmoothViterbi].type=cPitchSmootherViterbi
+
+[is13_pitchSmoothViterbi:cPitchSmootherViterbi]
+reader.dmLevel=is13_pitchShsG60
+reader2.dmLevel=is13_pitchShsG60
+writer.dmLevel=is13_pitchG60_viterbi
+\{\cm[bufferModeRbLagConf]}
+copyInputName = 1
+bufferLength=30
+F0final = 1
+F0finalEnv = 0
+voicingFinalClipped = 0
+voicingFinalUnclipped = 1
+F0raw = 0
+voicingC1 = 0
+voicingClip = 0
+wTvv =10.0
+wTvvd= 5.0
+wTvuv=10.0
+wThr = 4.0
+wTuu = 0.0
+wLocal=2.0
+wRange=1.0
+
+[componentInstances:cComponentManager]
+instance[is13_volmerge].type = cValbasedSelector
+
+[is13_volmerge:cValbasedSelector]
+reader.dmLevel = is13_e60;is13_pitchG60_viterbi
+writer.dmLevel = is13_pitchG60
+\{\cm[bufferModeRbLagConf]}
+idx=0
+threshold=0.001
+removeIdx=1
+zeroVec=1
+outputVal=0.0
+
+;;;;;;;;;;;;;;;;;;; Voice Quality (VQ)
+
+[componentInstances:cComponentManager]
+instance[is13_pitchJitter].type=cPitchJitter
+
+[is13_pitchJitter:cPitchJitter]
+reader.dmLevel = wave
+writer.dmLevel = is13_jitterShimmer
+\{\cm[bufferModeRbLagConf]}
+copyInputName = 1
+F0reader.dmLevel = is13_pitchG60
+F0field = F0final
+searchRangeRel = 0.250000
+jitterLocal = 1
+jitterDDP = 1
+jitterLocalEnv = 0
+jitterDDPEnv = 0
+shimmerLocal = 1
+shimmerLocalEnv = 0
+onlyVoiced = 0
+logHNR = 1
+inputMaxDelaySec = 2.0
+;periodLengths = 0
+;periodStarts = 0
+useBrokenJitterThresh = 1
+
+;;;;;;;;;;;;;;;;;;;;; Energy / loudness
+
+
+[componentInstances:cComponentManager]
+instance[is13_energy].type=cEnergy
+instance[is13_melspec1].type=cMelspec
+instance[is13_audspec].type=cPlp
+instance[is13_audspecRasta].type=cPlp
+instance[is13_audspecSum].type=cVectorOperation
+instance[is13_audspecRastaSum].type=cVectorOperation
+
+[is13_energy:cEnergy]
+reader.dmLevel = is13_frame25
+writer.dmLevel = is13_energy
+log=0
+rms=1
+; Enable this only for if quadratic energy is needed, otherwise it breaks ComParE feature set compatibility!!
+;  energy2=1
+
+[is13_melspec1:cMelspec]
+reader.dmLevel=is13_fftmagH25
+writer.dmLevel=is13_melspec1
+; htk compatible sample value scaling
+htkcompatible = 0
+nBands = 26
+; use power spectrum instead of magnitude spectrum
+usePower = 1
+lofreq = 20
+hifreq = 8000
+specScale = mel
+showFbank = 0
+
+; perform auditory weighting of spectrum
+[is13_audspec:cPlp]
+reader.dmLevel=is13_melspec1
+writer.dmLevel=is13_audspec
+firstCC = 0
+lpOrder = 5
+cepLifter = 22
+compression = 0.33
+htkcompatible = 0 
+doIDFT = 0
+doLpToCeps = 0
+doLP = 0
+doInvLog = 0
+doAud = 1
+doLog = 0
+newRASTA=0
+RASTA=0
+
+; perform RASTA style filtering of auditory spectra
+[is13_audspecRasta:cPlp]
+reader.dmLevel=is13_melspec1
+writer.dmLevel=is13_audspecRasta
+nameAppend = Rfilt
+firstCC = 0
+lpOrder = 5
+cepLifter = 22
+compression = 0.33
+htkcompatible = 0 
+doIDFT = 0
+doLpToCeps = 0
+doLP = 0
+doInvLog = 0
+doAud = 1
+doLog = 0
+newRASTA=1
+RASTA=0
+
+[is13_audspecSum:cVectorOperation]
+reader.dmLevel = is13_audspec
+writer.dmLevel = is13_audspecSum
+// nameAppend = 
+copyInputName = 1
+processArrayFields = 0
+operation = ll1
+nameBase = audspec
+
+[is13_audspecRastaSum:cVectorOperation]
+reader.dmLevel = is13_audspecRasta
+writer.dmLevel = is13_audspecRastaSum
+// nameAppend = 
+copyInputName = 1
+processArrayFields = 0
+operation = ll1
+nameBase = audspecRasta
+
+;;;;;;;;;;;;;;; spectral
+
+[componentInstances:cComponentManager]
+instance[is13_spectral].type=cSpectral
+
+
+[is13_spectral:cSpectral]
+reader.dmLevel=is13_fftmagH25
+writer.dmLevel=is13_spectral
+bands[0]=250-650
+bands[1]=1000-4000
+rollOff[0] = 0.25
+rollOff[1] = 0.50
+rollOff[2] = 0.75
+rollOff[3] = 0.90
+flux=1
+centroid=1
+maxPos=0
+minPos=0
+entropy=1
+variance=1
+skewness=1
+kurtosis=1
+slope=1
+harmonicity=1
+sharpness=1
+
+
+;;;;;;;;;;;;;;; mfcc
+
+[componentInstances:cComponentManager]
+instance[is13_melspecMfcc].type=cMelspec
+instance[is13_mfcc].type=cMfcc
+
+[is13_melspecMfcc:cMelspec]
+reader.dmLevel=is13_fftmagH25
+writer.dmLevel=is13_melspecMfcc
+copyInputName = 1
+processArrayFields = 1
+; htk compatible sample value scaling
+htkcompatible = 1
+nBands = 26
+; use power spectrum instead of magnitude spectrum
+usePower = 1
+lofreq = 20
+hifreq = 8000
+specScale = mel
+inverse = 0
+
+[is13_mfcc:cMfcc]
+reader.dmLevel=is13_melspecMfcc
+writer.dmLevel=is13_mfcc1_12
+copyInputName = 0
+processArrayFields = 1
+firstMfcc = 1
+lastMfcc  = 14
+cepLifter = 22.0
+htkcompatible = 1
+
+
+;;;;;;;;;;;;;;;;  zcr
+
+[componentInstances:cComponentManager]
+instance[is13_mzcr].type=cMZcr
+
+[is13_mzcr:cMZcr]
+reader.dmLevel = is13_frame60
+writer.dmLevel = is13_zcr
+copyInputName = 1
+processArrayFields = 1
+zcr = 1
+mcr = 0
+amax = 0
+maxmin = 0
+dc = 0
+
+
+;;;;;;;;;;;;;;;;;;;; smoothing
+
+[componentInstances:cComponentManager]
+instance[is13_smoNz].type=cContourSmoother
+instance[is13_smoA].type=cContourSmoother
+instance[is13_smoB].type=cContourSmoother
+instance[is13_f0sel].type=cDataSelector
+
+[is13_smoNz:cContourSmoother]
+reader.dmLevel = is13_pitchG60;is13_jitterShimmer
+writer.dmLevel = is13_lld_nzsmo
+\{\cm[bufferModeConf{../shared/BufferMode.conf.inc}:path to included config to set the buffer mode for the levels before the functionals]}
+nameAppend = sma
+copyInputName = 1
+noPostEOIprocessing = 0
+smaWin = 3
+noZeroSma = 1
+
+[is13_f0sel:cDataSelector]
+reader.dmLevel = is13_lld_nzsmo
+writer.dmLevel = is13_lld_f0_nzsmo
+\{\cm[bufferModeConf]}
+nameAppend = ff0
+selected = F0final_sma
+
+[is13_smoA:cContourSmoother]
+reader.dmLevel = is13_audspecSum;is13_audspecRastaSum;is13_energy;is13_zcr
+writer.dmLevel = is13_lldA_smo
+\{\cm[bufferModeConf]}
+nameAppend = sma
+copyInputName = 1
+noPostEOIprocessing = 0
+smaWin = 3
+
+[is13_smoB:cContourSmoother]
+reader.dmLevel = is13_audspecRasta;is13_spectral;is13_mfcc1_12
+writer.dmLevel = is13_lldB_smo
+\{\cm[bufferModeConf]}
+nameAppend = sma
+copyInputName = 1
+noPostEOIprocessing = 0
+smaWin = 3
+
+;;;;;;;;; deltas
+[componentInstances:cComponentManager]
+instance[is13_deNz].type=cDeltaRegression
+instance[is13_deA].type=cDeltaRegression
+instance[is13_deB].type=cDeltaRegression
+instance[is13_def0sel].type=cDeltaRegression
+
+[is13_deNz:cDeltaRegression]
+reader.dmLevel = is13_lld_nzsmo
+writer.dmLevel = is13_lld_nzsmo_de
+\{\cm[bufferModeConf]}
+onlyInSegments = 1
+zeroSegBound = 1
+
+[is13_deA:cDeltaRegression]
+reader.dmLevel = is13_lldA_smo
+writer.dmLevel = is13_lldA_smo_de
+\{\cm[bufferModeConf]}
+
+[is13_deB:cDeltaRegression]
+reader.dmLevel = is13_lldB_smo
+writer.dmLevel = is13_lldB_smo_de
+\{\cm[bufferModeConf]}
+
+[is13_def0sel:cDeltaRegression]
+reader.dmLevel = is13_lld_f0_nzsmo
+writer.dmLevel = is13_lld_f0_nzsmo_de
+\{\cm[bufferModeConf]}
+onlyInSegments = 1
+zeroSegBound = 1
+
+

--- a/opensmile/core/define.py
+++ b/opensmile/core/define.py
@@ -19,6 +19,11 @@ class FeatureSet(enum.Enum):
     * :attr:`eGeMAPSv01b`
     * :attr:`eGeMAPSv02`
     * :attr:`emobase`
+    * :attr:`IS09`
+    * :attr:`IS10`
+    * :attr:`IS11`
+    * :attr:`IS12`
+    * :attr:`IS13`
 
     For references, see the papers on:
 
@@ -65,6 +70,7 @@ class FeatureSet(enum.Enum):
     IS11 = "is09-13/IS11_speaker_state"
     IS12 = "is09-13/IS12_speaker_trait_compat"
     IS13 = "is09-13/IS13_ComParE"
+
 
 class FeatureSetResolver(audobject.resolver.Base):
     r"""Custom value resolver for :class:`opensmile.FeatureSet`."""

--- a/opensmile/core/define.py
+++ b/opensmile/core/define.py
@@ -25,7 +25,12 @@ class FeatureSet(enum.Enum):
     * `ComParE 2016`_
     * GeMAPS_
     * eGeMAPS_
-    * emobase
+    * emobase_
+    * IS09_
+    * IS10_
+    * IS11_
+    * IS12_
+    * IS13_
 
     .. _ComParE 2016:
         http://www.tangsoo.de/documents/Publications/Schuller16-TI2.pdf
@@ -33,6 +38,16 @@ class FeatureSet(enum.Enum):
         https://sail.usc.edu/publications/files/eyben-preprinttaffc-2015.pdf
     .. _eGeMAPS:
         https://sail.usc.edu/publications/files/eyben-preprinttaffc-2015.pdf
+    .. _IS09:
+        https://opus.bibliothek.uni-augsburg.de/opus4/files/66757/i09_0312.pdf
+    .. _IS10:
+        https://opus.bibliothek.uni-augsburg.de/opus4/files/66767/i10_2794.pdf
+    .. _IS11:
+        https://opus.bibliothek.uni-augsburg.de/opus4/files/66989/i11_3201.pdf
+    .. _IS12:
+        https://opus.bibliothek.uni-augsburg.de/opus4/files/66988/i12_0254.pdf
+    .. _IS13:
+        http://www5.informatik.uni-erlangen.de/Forschung/Publikationen/2013/Schuller13-TI2.pdf
 
     """
 
@@ -45,7 +60,11 @@ class FeatureSet(enum.Enum):
     eGeMAPSv01b = "egemaps/v01b/eGeMAPSv01b"
     eGeMAPSv02 = "egemaps/v02/eGeMAPSv02"
     emobase = "emobase/emobase"
-
+    IS09 = "is09-13/IS09_emotion"
+    IS10 = "is09-13/IS10_paraling_compat"
+    IS11 = "is09-13/IS11_speaker_state"
+    IS12 = "is09-13/IS12_speaker_trait_compat"
+    IS13 = "is09-13/IS13_ComParE"
 
 class FeatureSetResolver(audobject.resolver.Base):
     r"""Custom value resolver for :class:`opensmile.FeatureSet`."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ build-backend = 'setuptools.build_meta'
 # ----- codespell ---------------------------------------------------------
 [tool.codespell]
 builtin = 'clear,rare,informal,usage,names'
-skip = './opensmile.egg-info,./build,./docs/api,./docs/_templates,./docs/examples'
+skip = './opensmile.egg-info,./build,./docs/api,./docs/_templates,./docs/examples,opensmile/core/config/is09-13/*.conf'
 
 
 # ----- pytest ------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setuptools.setup(
             "config/emobase/*",
             "config/gemaps/v01a/*",
             "config/gemaps/v01b/*",
+            "config/is09-13/*",
             "config/shared/*",
         ],
     },


### PR DESCRIPTION
This PR adds standard config files for the IS09-13 feature sets. The config files are all taken from [the original repo](https://github.com/audeering/opensmile) with the only change being the use of external source and sink components for reading/writing.

## Summary by Sourcery

Add standardized openSMILE config files for the IS09-13 feature sets, update the FeatureSet enum to include IS09--IS13, and include the new configs in the package distribution.

New Features:
- Add FeatureSet enum entries for IS09 through IS13 with doc links and config paths
- Provide openSMILE configuration files for IS09 emotion, IS10 paralinguistics (compatibility and core), IS11 speaker state, IS12 speaker trait compatibility, and IS13 ComParE (core, functionals, vocalist)

Enhancements:
- Use external source and sink components across all new configs

Build:
- Include config/is09-13 directory in package data