### PR TITLE
Update license year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,10 +4,10 @@
   Copyright (c) audEERING GmbH, Gilching, Germany. All rights reserved. 
   http://www.audeering.com/
 
-  Copyright (c) 2016-2020, audEERING GmbH
-  Copyright (c) 2013-2015, audEERING UG (haftungsbeschraenkt)
-  Copyright (c) 2008-2013, Institute for Human-Machine Communication, 
-                           Technische Universitaet Muenchen, Germany
+  Copyright (c) 2016-present, audEERING GmbH
+  Copyright (c) 2013-2015,    audEERING UG (haftungsbeschraenkt)
+  Copyright (c) 2008-2013,    Institute for Human-Machine Communication, 
+                              Technische Universitaet Muenchen, Germany
  
 Licensing terms & your rights
 =============================


### PR DESCRIPTION
Similar to https://github.com/audeering/opensmile/pull/83, ensures the license year stays always up to date, by setting its upper bound to -present.

## Summary by Sourcery

Documentation:
- Change license file upper bound year from a hardcoded value to "present" to keep it up to date