### PR TITLE
Update license year

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ Copyright © 2008-2013, Institute for Human-Machine Communication, Technische Un
 
 Copyright © 2013-2015, audEERING UG (haftungsbeschränkt)
 
-Copyright © 2016-2020, audEERING GmbH
+Copyright © 2016-present, audEERING GmbH
 
 Citing
 ------


### PR DESCRIPTION
Similar to https://github.com/audeering/opensmile-python/pull/127 ensures the license year stays always up to date, by setting its upper bound to -present.

## Summary by Sourcery

Documentation:
- Change license upper bound year from a hardcoded value to "present" to keep it up to date in README.rst

## Summary by Sourcery

Documentation:
- Change the license year upper bound in README to use "present" instead of a fixed year so it stays up to date.