### PR TITLE
CI: update checkout, setup-python, setup-uv

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -16,15 +16,15 @@ jobs:
         python-version: [ '3.10' ]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Install dependencies
       run: uv sync

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python 3.10
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.10'
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Install pre-commit hooks
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,18 +24,18 @@ jobs:
         - win_amd64
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       # Need more than a shallow clone to get version from tags
       with:
         fetch-depth: 2
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.10'
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Install build dependencies
       run: uv sync
@@ -66,7 +66,7 @@ jobs:
     steps:
 
     - name: Clone repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       # Need depth to get diff for changelog
       with:
         fetch-depth: 1
@@ -79,12 +79,12 @@ jobs:
         merge-multiple: true
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.10'
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Install dependencies
       run: uv sync

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,15 +16,15 @@ jobs:
         python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Setup Ubuntu
       run: |
@@ -39,8 +39,8 @@ jobs:
       run: uv run pytest
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
+        files: ./coverage.xml
       if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
## Summary

- `setup-uv`'s cache keys on `uv.lock`/`requirements*.txt`, neither of which exists here (no committed lockfile, by design), so caching never actually worked. Bumped `astral-sh/setup-uv` v4/v5 -> **v9.0.0** (`publish.yml` had both, in its two jobs): v9.0.0's default glob adds `pyproject.toml`, which is committed and changes exactly when a dependency does — so caching now works with no lockfile needed.
- Also bumped `actions/checkout` and `actions/setup-python` to **v7** across all four workflows, and `codecov/codecov-action` to **v7** in `test.yml`, clearing the "Node.js 20 is deprecated" warning entirely. `codecov-action`'s v5 rewrite dropped the `file` input this workflow used; renamed to `files`, its replacement.
- Left `prune-cache` at its new default (off): opensmile-python's only runtime dependencies are `audobject` and `audinterface`, with no torch-scale binary wheels in the dependency tree, so per [astral-sh/setup-uv#967](https://github.com/astral-sh/setup-uv/pull/967) pruning wouldn't pay off here either.

## Test plan

- [x] `git diff` limited to the exact action-version bumps (+ the one `file` -> `files` rename), no other content touched
- [x] All 4 changed workflow YAML files parse via `yaml.safe_load`
- [ ] CI run on this PR shows green + a working uv cache hit on subsequent runs

---

Same fix already merged as [audeering/audeer#206](https://github.com/audeering/audeer/pull/206), ported here for consistency.