### PR TITLE
Let only Test save the shared uv cache

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -25,6 +25,8 @@ jobs:
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        save-cache: false
 
     - name: Install dependencies
       run: uv sync

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,6 +21,8 @@ jobs:
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        save-cache: false
 
     - name: Install pre-commit hooks
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,8 @@ jobs:
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        save-cache: false
 
     - name: Install build dependencies
       run: uv sync
@@ -85,6 +87,8 @@ jobs:
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        save-cache: false
 
     - name: Install dependencies
       run: uv sync


### PR DESCRIPTION
## Problem

`astral-sh/setup-uv` derives its cache key from the runner architecture,
the runner image, the Python version and a hash of the dependency files:

```
setup-uv-2-x86_64-unknown-linux-gnu-ubuntu-24.04-3.10.20-69a2db3b0c51eec1981aed13262a263eaefdcc0830957d5848dfa77c059a7219
```

Nothing in that key identifies the workflow. Documentation
(ubuntu-latest, 3.10), Linter (ubuntu-latest, 3.10) and the
ubuntu-latest/3.10 leg of Test therefore derive a byte-identical key, and
one push starts all three at once. At save time they race to reserve it;
only the first to finish wins, and the losers log:

```
Failed to save: Unable to reserve cache with key setup-uv-2-x86_64-unknown-linux-gnu-ubuntu-24.04-3.10.20-69a2db3b0c51eec1981aed13262a263eaefdcc0830957d5848dfa77c059a7219, another job may be creating this cache.
```

It is save-time only and harmless — the loser's content would have been
identical to the winner's — but it is a yellow annotation on an
otherwise green run.

Measured on `main`: **1 annotation across the last six pushes**, all of
it on the one push that has run since `setup-uv` was bumped to v9.0.0.
Push a41c0bd (["Fix CI caching; bump checkout/setup-python off Node.js
20"](https://github.com/audeering/opensmile-python/commit/a41c0bd5b6a674df1a26db9fa62208b5f9a36906)),
17 check-runs, 1 warning:

| Workflow | Job | Derived key | Outcome | Run |
| --- | --- | --- | --- | --- |
| Linter | `build` | `…-ubuntu-24.04-3.10.20-69a2db3b…` | `uv cache saved with key: …` — won the reservation | [30999400955](https://github.com/audeering/opensmile-python/actions/runs/30999400955) |
| Test | `build (ubuntu-latest, 3.10)` | `…-ubuntu-24.04-3.10.20-69a2db3b…` | **`Failed to save: Unable to reserve cache …`** | [30999401311](https://github.com/audeering/opensmile-python/actions/runs/30999401311) |
| Documentation | `build (ubuntu-latest, 3.10)` | `…-ubuntu-24.04-3.10.20-69a2db3b…` | no save attempt — the job fails earlier for an unrelated reason (see below), and `setup-uv`'s post step is `post-if: success()` | [30999400946](https://github.com/audeering/opensmile-python/actions/runs/30999400946) |

All three logged `No GitHub Actions cache found for key: …69a2db3b…`
at restore, so all three were candidates to save. Documentation is a
third contender that is only masked today: it fails at `Test building
documentation` with `RuntimeError: Cannot find version '1.1.1' for
database 'emodb'`, a pre-existing failure on `main` unrelated to this PR,
which aborts the job before the save step runs. Fix that and the same
push produces two warnings instead of one.

The five earlier pushes show zero such annotations; they ran
`astral-sh/setup-uv@v5` and their logs are past GitHub's retention
window, so the key they derived can no longer be inspected.

## Fix

Keep the single shared key and make exactly one workflow the writer.
`save-cache: false` (an input of `setup-uv` v9.0.0, default `true`) turns
off saving while leaving restore intact:

- `doc.yml` — stops saving
- `linter.yml` — stops saving
- `publish.yml` — stops saving, **both** `setup-uv` steps (`build` and `deploy`)
- `test.yml` — untouched, sole saver

Test's matrix is a pure 3-OS x 5-Python cross product, so every leg
derives a distinct key and there is no race inside it. Everyone still
restores the same shared cache; only Test writes it.

As a side effect this also removes a collision that would have hit
`publish.yml` on the next release: its `build` job is a 6-way `platform`
matrix that all runs on `ubuntu-latest` with Python 3.10 and the same
dependency hash, so all six legs derive one key. With `save-cache: false`
none of them tries to save.

## Trade-off

After a cache-key rotation — a `pyproject.toml` or `uv.lock` change, a
runner image bump, a Python patch bump — the non-saving workflows miss
once, because the new key does not exist until the next Test run writes
it. That is a fresh `uv` download in Documentation, Linter and Publish
for a single run: a second or two per job, once. From the following run
on, they restore normally.

## Context

Ports [audeering/audeer#207](https://github.com/audeering/audeer/pull/207)
(merged, reviewer-approved), where the single-saver design was chosen
over per-workflow `cache-suffix` values — the latter removes the warning
by storing several identical copies of the same cache, which was rejected
as wasteful.

`audformat` and `audb` get the same treatment.

This repo's `main` never received the fix: its caching PR merged before
the warning was diagnosed, which is why a41c0bd is the push that shows
it.

## Test plan

- [ ] All checks green, except the pre-existing Documentation failure
      (`Cannot find version '1.1.1' for database 'emodb'`), which also
      fails on `main` at a41c0bd
- [ ] Zero `Unable to reserve cache` annotations across every check-run
      on the head SHA
- [ ] Documentation, Linter show `save-cache is false. Skipping save
      cache step.` after restoring
- [ ] Test's `build (ubuntu-latest, 3.10)` saves or hits the shared key
